### PR TITLE
ci: expand pytest workflow and headless test setup

### DIFF
--- a/.github/workflows/pytest_runs.yml
+++ b/.github/workflows/pytest_runs.yml
@@ -2,33 +2,70 @@ name: pytest
 
 on:
   pull_request:
-    branches:    
+    branches:
+      - master
+      - dev
+  push:
+    branches:
       - master
       - dev
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytests:
+    name: pytest / ${{ matrix.os }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+
     env:
       PYTHONPATH: ${{ github.workspace }}
-    steps:
-      - name: Check out pipeline code
-        uses: actions/checkout@v3
+      PYGAME_HIDE_SUPPORT_PROMPT: "1"
+      SDL_VIDEODRIVER: dummy
+      SDL_AUDIODRIVER: dummy
+      PYTHONUTF8: "1"
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python -m pip install -r requirements.txt
 
-      - name: run the tests
-        run: pytest tests/
+      - name: Show environment
+        run: |
+          python --version
+          python -m pip freeze
 
+      - name: Compile Python files
+        run: python -m compileall -q -x "(.git|__pycache__)" .
+
+      - name: Run tests
+        run: python -m pytest -q tests/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,12 @@
 .RData
 .Ruserdata
 venv
+.venv/
+.venv*/
+.pytest_cache/
+__pycache__/
 *.pyc
+*.pyo
 .DS_Store
 
 intro/

--- a/README.md
+++ b/README.md
@@ -54,14 +54,18 @@ Setting up from source is possible however.
 
 ### From source
 
-* [Python 3.10](https://www.python.org/downloads/)
+* Python 3.10 or newer
 * [Pygame](http://www.pygame.org/)
-* Python Image Module: [PIL](https://pillow.readthedocs.io)
+* Python Image Module: [PIL/Pillow](https://pillow.readthedocs.io)
+* [pyproj](https://pyproj4.github.io/pyproj/) and [NumPy](https://numpy.org/)
 
-You can all install through pip
+Create a virtual environment and install the dependencies from the repository root:
 
 ```
-pip install -r requirements.txt
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 ```
 
 Then run by starting the intro.py file.
@@ -69,6 +73,23 @@ Then run by starting the intro.py file.
 In either case it can then be run by typing:
 ```
 python intro.py
+```
+
+### Running tests
+
+The test suite is headless-friendly. From a configured virtual environment:
+
+```
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 python -m pytest -q
+```
+
+On Windows PowerShell, set the environment variables first:
+
+```
+$env:SDL_VIDEODRIVER="dummy"
+$env:SDL_AUDIODRIVER="dummy"
+$env:PYGAME_HIDE_SUPPORT_PROMPT="1"
+python -m pytest -q
 ```
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Shared pytest configuration for High Frontier.
+
+The game uses pygame at import time in a few modules.  These defaults let the
+existing test suite and future GUI smoke tests run on headless CI runners.
+"""
+
+import os
+
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")


### PR DESCRIPTION
## Summary
- Expands the GitHub Actions pytest workflow across supported Python/OS combinations.
- Adds headless pygame environment defaults for CI.
- Adds pytest configuration and test bootstrap helpers so local/CI test runs are easier to reproduce.
- Updates README setup/test notes and ignores common local artifacts.

## Test Plan
- `python -m compileall .`
- `pytest`

## Risks/Notes
- This is intended as the first, safest inspection PR: it raises the project’s testing floor before larger gameplay/UI/save-game work.
- No gameplay behavior changes intended.