### PR TITLE
fix: harden pickle save/load image handling

### DIFF
--- a/SimThread.py
+++ b/SimThread.py
@@ -8,10 +8,10 @@ class SimThread(threading.Thread):
         threading.Thread.__init__(self)
         self.sol=sol
         self._stopEvent=threading.Event()
-        self.setDaemon(True)
+        self.daemon = True
     def run(self):
         sol=self.sol
-        while(not self._stopEvent.isSet()):
+        while(not self._stopEvent.is_set()):
 #            print "SimThread starting another month"
             sol.current_date = datetime.timedelta(30)+sol.current_date
             sol.evaluate_each_game_step()

--- a/solarsystem.py
+++ b/solarsystem.py
@@ -357,7 +357,7 @@ class solarsystem:
                     image = getattr(planet_instance, known_planet_image)
                     size = image.size
                     mode = image.mode
-                    image_string = image.tostring()
+                    image_string = image.tobytes()
                     setattr(planet_instance, known_planet_image, {"string":image_string,"mode":mode,"size":size})
             if planet_instance.pre_drawn_surfaces != {}:
                 backup_up_pre_drawn_surfaces[planet_instance.name] = {}
@@ -374,28 +374,44 @@ class solarsystem:
                     image_string = image.tobytes()
                     planet_instance.resource_maps[resource] = {"string":image_string,"mode":mode,"size":size}
 
+        tmp_filename = filename + ".tmp"
+        simulation_thread_was_running = hasattr(self, 'simThread')
         try:
-          file = open(filename, "wb")  # Open the file in binary mode for pickle
-
-          if hasattr(self, 'simThread'):
+          if simulation_thread_was_running:
               self.simThread.join()  # Wait for the simulation thread to finish
               del self.simThread  # Delete the thread reference
-              pickle.dump(self, file)
+              with open(tmp_filename, "wb") as file:
+                  pickle.dump(self, file)
+                  file.flush()
+                  os.fsync(file.fileno())
+              os.replace(tmp_filename, filename)
               self.launchThread()
           else:
-              pickle.dump(self, file)
+              with open(tmp_filename, "wb") as file:
+                  pickle.dump(self, file)
+                  file.flush()
+                  os.fsync(file.fileno())
+              os.replace(tmp_filename, filename)
           print("Game saved successfully.")
         except MemoryError:
+          if os.path.exists(tmp_filename):
+            os.remove(tmp_filename)
+          if simulation_thread_was_running and not hasattr(self, 'simThread'):
+            self.launchThread()
           print("Error: MemoryError occurred while saving the game. Consider freeing up memory or using a system with more memory.")
         except pickle.PickleError as e:
+          if os.path.exists(tmp_filename):
+            os.remove(tmp_filename)
+          if simulation_thread_was_running and not hasattr(self, 'simThread'):
+            self.launchThread()
           print(f"Error: Failed to pickle the game. Details: {e}")
         except Exception as e:
+          if os.path.exists(tmp_filename):
+            os.remove(tmp_filename)
+          if simulation_thread_was_running and not hasattr(self, 'simThread'):
+            self.launchThread()
           print(f"Error: An unexpected error occurred while saving the game. Details: {e}")
-        finally:
-          if 'file' in locals() and not file.closed:
-            file.close()
 
-        #here we restore the pre_drawn surfaces
         for planet_name in backup_up_pre_drawn_surfaces:
             planet_instance = self.planets[planet_name]
             for pre_drawn_surface_key in backup_up_pre_drawn_surfaces[planet_name]:
@@ -406,13 +422,12 @@ class solarsystem:
             for known_planet_image in known_planet_images:
                 if hasattr(planet_instance, known_planet_image):
                     image_parts = getattr(planet_instance, known_planet_image)
-                    image = Image.fromstring(image_parts["mode"],image_parts["size"],image_parts["string"])
+                    image = Image.frombytes(image_parts["mode"],image_parts["size"],image_parts["string"])
                     setattr(planet_instance, known_planet_image, image)
             if planet_instance.resource_maps != {}:
                 for resource in planet_instance.resource_maps:
                     image_parts = planet_instance.resource_maps[resource]
-                    if image.format:
-                      image = Image.fromstring(image_parts["mode"],image_parts["size"],image_parts["string"])
+                    image = Image.frombytes(image_parts["mode"],image_parts["size"],image_parts["string"])
                     planet_instance.resource_maps[resource] = image
 
 
@@ -420,7 +435,6 @@ class solarsystem:
         """
         Function that loads the solar system
         """
-        file = open(filename, "r")
         try:
             with open(filename, "rb") as file:
                 new_solar_system = pickle.load(file)
@@ -433,15 +447,13 @@ class solarsystem:
             error_message = str(e)
             print(error_message)
             raise Exception(f"An error of type: {error_message} was found")
-        finally:
-            file.close()
         #here we de-stringify the resource maps and other known planet images
         known_planet_images = ["wet_areas","topo_image"]
         for planet_instance in list(new_solar_system.planets.values()):
             for known_planet_image in known_planet_images:
                 if hasattr(planet_instance, known_planet_image):
                     image_parts = getattr(planet_instance, known_planet_image)
-                    image = Image.fromstring(image_parts["mode"],image_parts["size"],image_parts["string"])
+                    image = Image.frombytes(image_parts["mode"],image_parts["size"],image_parts["string"])
                     setattr(planet_instance, known_planet_image, image)
             if planet_instance.resource_maps != {}:
                 for resource in planet_instance.resource_maps:
@@ -449,23 +461,15 @@ class solarsystem:
                     image = Image.frombytes(image_parts["mode"],image_parts["size"],image_parts["string"])
                     planet_instance.resource_maps[resource] = image
         #inserting all variables in self
-        for entry_name in dir(self):
-            if entry_name == '__weakref__':
-                continue
-            if not hasattr(new_solar_system, entry_name):
-                delattr(self,entry_name)
-        for entry_name in dir(new_solar_system):
-            if entry_name == '__weakref__':
-                continue
-            entry = getattr(new_solar_system, entry_name)
-            setattr(self,entry_name, entry)
+        self.__dict__.clear()
+        self.__dict__.update(new_solar_system.__dict__)
         #updating all solar_system_object_links (this is actually rather weird that it has to be done)
         for company_instance in list(self.companies.values()):
             company_instance.solar_system_object_link = self
             for owned_firm_instance in list(company_instance.owned_firms.values()):
                 owned_firm_instance.solar_system_object_link = self
         for planet_instance in list(self.planets.values()):
-            planet_instance.solars_system_object_link = self
+            planet_instance.solar_system_object_link = self
         self.technology_tree.solar_system_object_link = self
     def get_satellite_to_center_position(self,object,zoom_level,date_variable):
         """

--- a/tests/test_solarsystem.py
+++ b/tests/test_solarsystem.py
@@ -110,3 +110,39 @@ def test_save_and_load_solar_system(tmpdir):
     assert compare_attributes(old_solar_system, new_solar_system, max_depth=10), "Attributes of old and new solar system instances are not the same"
 
 
+def test_save_and_load_solar_system_with_loaded_planet_images(tmpdir):
+    """Saving should survive planet PIL images/resource maps loaded in memory.
+
+    Planet drawing lazily loads images that cannot be pickled directly.  This
+    regression test exercises the conversion/restoration path that ordinary
+    bare save/load tests miss.
+    """
+    save_file_path = os.path.join(tmpdir.mkdir("save_files"), "image_save_file.pkl")
+
+    old_solar_system = solarsystem(start_date=global_variables.start_date)
+    old_solar_system.initialize_planets()
+    earth = old_solar_system.planets["earth"]
+    earth.calculate_topography()
+    earth.calculate_resource_map("iron")
+
+    original_topo_size = earth.topo_image.size
+    original_resource_size = earth.resource_maps["iron"].size
+
+    old_solar_system.save_solar_system(save_file_path)
+
+    assert isinstance(earth.topo_image, Image.Image)
+    assert isinstance(earth.resource_maps["iron"], Image.Image)
+    assert earth.topo_image.size == original_topo_size
+    assert earth.resource_maps["iron"].size == original_resource_size
+
+    new_solar_system = solarsystem(start_date=global_variables.start_date)
+    new_solar_system.load_solar_system(save_file_path)
+    loaded_earth = new_solar_system.planets["earth"]
+
+    assert isinstance(loaded_earth.topo_image, Image.Image)
+    assert isinstance(loaded_earth.resource_maps["iron"], Image.Image)
+    assert loaded_earth.topo_image.size == original_topo_size
+    assert loaded_earth.resource_maps["iron"].size == original_resource_size
+    assert loaded_earth.solar_system_object_link is new_solar_system
+
+


### PR DESCRIPTION
## Summary
- Adds a regression test covering save/load after planet topography/resource-map PIL images have been loaded.
- Replaces removed Pillow APIs (`tostring`/`fromstring`) with current byte serialization APIs.
- Writes saves through a temporary file plus atomic replace to reduce corrupt/partial saves.
- Restores object state through `__dict__` rather than copying from `dir()`.
- Fixes resource-map restore and planet back-reference issues found while tracing the save path.
- Updates deprecated thread API calls encountered during the same reliability pass.

## Test Plan
- New regression test failed before the fix with `AttributeError: 'PngImageFile' object has no attribute 'tostring'`.
- Targeted regression test passes after fix.
- `pytest` → `23 passed, 1 warning`
- `python -m compileall .`

## Risks/Notes
- This intentionally keeps the existing pickle-backed save format for now; it hardens the current path rather than introducing a new versioned save system in one risky step.
- Longer-term save migration should be a separate PR after this baseline is reviewed.