### PR TITLE
chore: add repository code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner for all files in this repository.
+* @lassefolkersen


### PR DESCRIPTION
## Summary
- Adds a root `CODEOWNERS` file assigning all repository files to `@lassefolkersen`.

## Test Plan
- Not run; repository ownership metadata only.

## Risks/Notes
- This enables branch protection rules to require review from the configured code owner once CODEOWNERS-based review is enabled in GitHub settings.
