### PR TITLE
fix: restore fast list column sorting

### DIFF
--- a/gui_components.py
+++ b/gui_components.py
@@ -862,14 +862,10 @@ class fast_list():
                 else:
                     temp_dict = {}
 
-                    #from http://mail.python.org/pipermail/python-list/2002-May/146190.html - thanks xtian
                     for row in data:
                         temp_dict[row] = data[row][sort_by]
-                    def sorter(x, y):
-                        return cmp(x[1],y[1])
 
-                    i = list(temp_dict.items())
-                    i.sort(sorter)
+                    i = sorted(temp_dict.items(), key=lambda item: item[1])
                     sorting_list = []
                     for i_entry in i:
                         sorting_list.append(i_entry[0])

--- a/tests/test_gui_components.py
+++ b/tests/test_gui_components.py
@@ -1,0 +1,73 @@
+import types
+
+import pygame
+
+import gui_components
+
+
+def _surface():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    return pygame.Surface((320, 200))
+
+
+def _sample_rows():
+    return {
+        "bravo": {"score": 2, "name": "B"},
+        "alpha": {"score": 1, "name": "A"},
+    }
+
+
+def test_fast_list_sorts_tabular_rows_by_requested_column():
+    widget = gui_components.fast_list(
+        _surface(),
+        _sample_rows(),
+        pygame.Rect(0, 0, 260, 120),
+        column_order=["rownames", "score", "name"],
+        sort_by="score",
+    )
+
+    assert widget.data[0].startswith("alpha")
+    assert widget.data[1].startswith("bravo")
+
+
+def test_fast_list_reverse_sorts_tabular_rows_by_requested_column():
+    widget = gui_components.fast_list(
+        _surface(),
+        _sample_rows(),
+        pygame.Rect(0, 0, 260, 120),
+        column_order=["rownames", "score", "name"],
+        sort_by="score",
+    )
+
+    widget.receive_data(
+        _sample_rows(),
+        sort_by="score",
+        column_order=["rownames", "score", "name"],
+        reverse_sort=True,
+    )
+
+    assert widget.data[0].startswith("bravo")
+    assert widget.data[1].startswith("alpha")
+
+
+def test_fast_list_header_click_on_known_column_resorts_without_error():
+    widget = gui_components.fast_list(
+        _surface(),
+        _sample_rows(),
+        pygame.Rect(0, 0, 260, 120),
+        column_order=["rownames", "score", "name"],
+        sort_by="rownames",
+    )
+    assert widget.title is not None
+    score_span = next(
+        span
+        for span, column_name in widget.title["entry_span"].items()
+        if column_name == "score"
+    )
+    click = types.SimpleNamespace(pos=(score_span[0] + 1, widget.rect[1] + 1))
+
+    widget.receive_click(click)
+
+    assert widget.sorted_by_this_column == "score"
+    assert widget.data[0].startswith("alpha")


### PR DESCRIPTION
## Summary
- Add headless smoke/regression coverage for `gui_components.fast_list` column sorting.
- Replace the removed Python 2 comparator-style sort with Python 3 key-based sorting.
- Verify header-click resorting continues to work without changing the retro Pygame rendering path.

## Test Plan
- `PYTHONDONTWRITEBYTECODE=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/hermes/work/hfvenv/bin/python -m pytest -q tests/test_gui_components.py`
- `PYTHONDONTWRITEBYTECODE=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/hermes/work/hfvenv/bin/python -m pytest -q`
- `/home/hermes/work/hfvenv/bin/python -m compileall -q -x "(.git|__pycache__)" .`

## Risks/Notes
- Narrow UI code polish change; no controls or visuals intentionally changed.
- Tests run under dummy SDL and exercise ordering behavior rather than pixels.
