### PR TITLE
refactor: guard intro startup and resolve asset paths

### DIFF
--- a/global_variables.py
+++ b/global_variables.py
@@ -4,6 +4,7 @@ import pygame
 import time
 import market_decisions
 import os
+from paths import asset_path
 pygame.font.init()
 
 # variables that are "meta-gamespecific" ie. that should not follow a savegame
@@ -18,10 +19,10 @@ persons_per_company = 1200000   #upper limit on the number of companies relative
 max_transactions_tracked = 100 #the max number of tracked transaction in a market.
 max_letters_in_company_names = 32
 
-courier_font = pygame.font.Font(os.path.join("fonts","CRYSRG__.TTF"), 11) #some fonts
+courier_font = pygame.font.Font(asset_path("fonts","CRYSRG__.TTF"), 11) #some fonts
 standard_font = pygame.font.SysFont(os.path.join("fonts","freesansbold.ttf"), 13, bold=False, italic=False) #some fonts
-standard_font_small= pygame.font.Font(os.path.join("fonts","freesansbold.ttf"),10)
-standard_font_small_bold = pygame.font.Font(os.path.join("fonts","freesansbold.ttf"),10)
+standard_font_small= pygame.font.Font(asset_path("fonts","freesansbold.ttf"),10)
+standard_font_small_bold = pygame.font.Font(asset_path("fonts","freesansbold.ttf"),10)
 standard_font_small_bold.set_bold(True)
 max_stepback_history_size = 10 # how many steps back we can use the "back" key
 market_decisions = market_decisions.market_decisions() #this is the class of market decisions that should be globally available.

--- a/intro.py
+++ b/intro.py
@@ -13,6 +13,7 @@ import global_variables
 import gui_components
 import main
 import primitives
+from paths import asset_path
 
 
 class IntroGui:
@@ -63,7 +64,7 @@ class IntroGui:
             self.window = pygame.display.set_mode(global_variables.window_size,FULLSCREEN)
         else:
             self.window = pygame.display.set_mode(global_variables.window_size)
-        icon = pygame.image.load(os.path.join("images","window_icon.png"))
+        icon = pygame.image.load(asset_path("images","window_icon.png"))
         pygame.display.set_icon(icon)
 
         if global_variables.fullscreen:
@@ -482,4 +483,5 @@ class IntroGui:
             self.ask_company_capital(None, None, give_warning=True)
 
 
-introGui = IntroGui()
+if __name__ == "__main__":
+    IntroGui()

--- a/paths.py
+++ b/paths.py
@@ -1,0 +1,21 @@
+"""Filesystem path helpers for High Frontier assets and data files."""
+
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parent
+
+
+def repo_root() -> Path:
+    """Return the repository/application root directory."""
+    return _REPO_ROOT
+
+
+def asset_path(*parts: str) -> Path:
+    """Return an absolute path for a bundled runtime asset."""
+    return _REPO_ROOT.joinpath(*parts)
+
+
+def data_path(*parts: str) -> Path:
+    """Return an absolute path under the bundled data directory."""
+    return _REPO_ROOT.joinpath("data", *parts)

--- a/tests/test_intro_import.py
+++ b/tests/test_intro_import.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+import types
+
+
+def test_importing_intro_does_not_start_intro_gui(monkeypatch):
+    class GameStartedAtImport(RuntimeError):
+        pass
+
+    class ExplodingGame:
+        def __init__(self):
+            raise GameStartedAtImport("intro constructed Game during import")
+
+    pygame_stub = types.ModuleType("pygame")
+    pygame_locals_stub = types.ModuleType("pygame.locals")
+    setattr(pygame_stub, "Surface", object)
+    setattr(pygame_stub, "locals", pygame_locals_stub)
+    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
+    monkeypatch.setitem(sys.modules, "pygame.locals", pygame_locals_stub)
+    monkeypatch.setitem(sys.modules, "solarsystem", types.ModuleType("solarsystem"))
+    monkeypatch.setitem(sys.modules, "planet", types.ModuleType("planet"))
+    monkeypatch.setitem(sys.modules, "global_variables", types.ModuleType("global_variables"))
+    monkeypatch.setitem(sys.modules, "gui_components", types.ModuleType("gui_components"))
+    monkeypatch.setitem(sys.modules, "primitives", types.ModuleType("primitives"))
+    main_stub = types.ModuleType("main")
+    setattr(main_stub, "Game", ExplodingGame)
+    monkeypatch.setitem(sys.modules, "main", main_stub)
+    sys.modules.pop("intro", None)
+
+    importlib.import_module("intro")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import sys
+
+from paths import asset_path, data_path, repo_root
+
+
+def test_asset_and_data_paths_are_absolute_existing_files():
+    assert repo_root().is_absolute()
+    assert asset_path("images", "window_icon.png").is_absolute()
+    assert asset_path("images", "window_icon.png").exists()
+    assert data_path("planets.txt").is_absolute()
+    assert data_path("planets.txt").exists()
+
+
+def test_global_variables_imports_from_non_repo_cwd(tmp_path):
+    env = os.environ.copy()
+    env.update(
+        {
+            "PYTHONPATH": str(repo_root()),
+            "PYGAME_HIDE_SUPPORT_PROMPT": "1",
+            "SDL_VIDEODRIVER": "dummy",
+            "SDL_AUDIODRIVER": "dummy",
+        }
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import global_variables; print(global_variables.courier_font.size('x'))",
+        ],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()


### PR DESCRIPTION
## Summary
- Guard `intro.py` startup with `if __name__ == "__main__"` so import-time tooling/tests do not launch the menu loop.
- Add small path helpers for repository-relative assets/data.
- Use the asset helper for the highest-risk import-time font loads and the intro window icon.

## Test Plan
- `PYTHONDONTWRITEBYTECODE=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/hermes/work/hfvenv/bin/python -m pytest -q tests/test_intro_import.py tests/test_paths.py`
- `PYTHONDONTWRITEBYTECODE=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/hermes/work/hfvenv/bin/python -m pytest -q`
- `/home/hermes/work/hfvenv/bin/python -m compileall -q -x "(.git|__pycache__)" .`

## Risks/Notes
- `python intro.py` behavior is preserved; importing `intro` no longer starts the game.
- This intentionally stages path modernization narrowly to avoid broad packaging/save compatibility risk.
