### PR TITLE
feat: add crash logging hooks

### DIFF
--- a/SimThread.py
+++ b/SimThread.py
@@ -2,6 +2,9 @@ import random
 import time
 import datetime
 import threading
+import logging
+
+logger = logging.getLogger(__name__)
 
 class SimThread(threading.Thread):
     def __init__(self,sol):
@@ -11,13 +14,17 @@ class SimThread(threading.Thread):
         self.daemon = True
     def run(self):
         sol=self.sol
-        while(not self._stopEvent.is_set()):
+        try:
+            while(not self._stopEvent.is_set()):
 #            print "SimThread starting another month"
-            sol.current_date = datetime.timedelta(30)+sol.current_date
-            sol.evaluate_each_game_step()
-            for company_instance in list(sol.companies.values()):
-                company_instance.evaluate_self()
-            time.sleep(1)
+                sol.current_date = datetime.timedelta(30)+sol.current_date
+                sol.evaluate_each_game_step()
+                for company_instance in list(sol.companies.values()):
+                    company_instance.evaluate_self()
+                time.sleep(1)
+        except Exception:
+            logger.exception("Unhandled exception in simulation thread")
+            raise
     def join(self,timeout=None):
         self._stopEvent.set()
         threading.Thread.join(self,timeout)

--- a/crashlog.py
+++ b/crashlog.py
@@ -1,0 +1,84 @@
+"""Crash logging helpers for High Frontier startup and background threads."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+from pathlib import Path
+import sys
+import threading
+from typing import Callable, TypeVar
+
+_LOGGER_NAME = "highfrontier"
+_HANDLER_MARKER = "_highfrontier_crashlog_handler"
+T = TypeVar("T")
+
+
+def log_dir_from_environment() -> Path:
+    configured = os.environ.get("HIGHFRONTIER_LOG_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".highfrontier" / "logs"
+
+
+def configure_logging(log_dir: str | os.PathLike[str] | None = None) -> Path:
+    """Configure rotating file logging and return the active log file path."""
+    directory = Path(log_dir).expanduser() if log_dir is not None else log_dir_from_environment()
+    directory.mkdir(parents=True, exist_ok=True)
+    log_file = directory / "highfrontier.log"
+
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        if getattr(handler, _HANDLER_MARKER, False):
+            root_logger.removeHandler(handler)
+            handler.close()
+
+    handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
+    setattr(handler, _HANDLER_MARKER, True)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s [%(threadName)s] %(name)s: %(message)s"
+        )
+    )
+    handler.setLevel(logging.INFO)
+    root_logger.addHandler(handler)
+    root_logger.setLevel(min(root_logger.level or logging.INFO, logging.INFO))
+    return log_file
+
+
+def install_excepthooks() -> None:
+    """Install sys/thread exception hooks that write full tracebacks to logs."""
+    logger = logging.getLogger(_LOGGER_NAME)
+
+    def log_unhandled_exception(exc_type, exc_value, exc_traceback):
+        logger.critical(
+            "Unhandled exception in main thread",
+            exc_info=(exc_type, exc_value, exc_traceback),
+        )
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+
+    def log_thread_exception(args: threading.ExceptHookArgs):
+        if args.exc_value is None:
+            logger.critical(
+                "Unhandled exception in thread %s",
+                args.thread.name if args.thread is not None else "<unknown>",
+            )
+            return
+        logger.critical(
+            "Unhandled exception in thread %s",
+            args.thread.name if args.thread is not None else "<unknown>",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+
+    sys.excepthook = log_unhandled_exception
+    threading.excepthook = log_thread_exception
+
+
+def run_with_crash_logging(context: str, func: Callable[..., T], *args, **kwargs) -> T:
+    """Run a callable, logging context and traceback before re-raising failures."""
+    try:
+        return func(*args, **kwargs)
+    except Exception:
+        logging.getLogger(_LOGGER_NAME).exception("Unhandled exception during %s", context)
+        raise

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ import global_variables
 import gui
 import random
 import importlib
+import crashlog
 
 
 
@@ -166,7 +167,13 @@ class Game:
 
 
 if __name__ == "__main__":
+    crashlog.configure_logging()
+    crashlog.install_excepthooks()
     game = Game()
-    game.start_loop(companyName = "asdf",
-                        companyCapital =  1000000,
-                        loadPreviousGame = None)
+    crashlog.run_with_crash_logging(
+        "main game loop",
+        game.start_loop,
+        companyName = "asdf",
+        companyCapital =  1000000,
+        loadPreviousGame = None,
+    )

--- a/tests/test_crashlog.py
+++ b/tests/test_crashlog.py
@@ -1,0 +1,46 @@
+import logging
+import threading
+
+import pytest
+
+import crashlog
+
+
+def _read_log_files(log_dir):
+    text = ""
+    for log_file in log_dir.glob("*.log"):
+        text += log_file.read_text()
+    return text
+
+
+def test_run_with_crash_logging_logs_and_reraises(tmp_path, monkeypatch):
+    monkeypatch.setenv("HIGHFRONTIER_LOG_DIR", str(tmp_path))
+    crashlog.configure_logging()
+
+    def fail():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        crashlog.run_with_crash_logging("unit test context", fail)
+
+    log_text = _read_log_files(tmp_path)
+    assert "unit test context" in log_text
+    assert "boom" in log_text
+    assert "Traceback" in log_text
+
+
+def test_threading_excepthook_logs_thread_exception(tmp_path, monkeypatch):
+    monkeypatch.setenv("HIGHFRONTIER_LOG_DIR", str(tmp_path))
+    crashlog.configure_logging()
+    crashlog.install_excepthooks()
+
+    def fail_in_thread():
+        raise RuntimeError("thread boom")
+
+    thread = threading.Thread(target=fail_in_thread, name="crashlog-test-thread")
+    thread.start()
+    thread.join()
+
+    log_text = _read_log_files(tmp_path)
+    assert "crashlog-test-thread" in log_text
+    assert "thread boom" in log_text

--- a/tests/test_simthread.py
+++ b/tests/test_simthread.py
@@ -1,0 +1,25 @@
+import datetime
+import logging
+
+import pytest
+
+from SimThread import SimThread
+
+
+class ExplodingSolarSystem:
+    def __init__(self):
+        self.current_date = datetime.date(2026, 1, 1)
+        self.companies = {}
+
+    def evaluate_each_game_step(self):
+        raise RuntimeError("sim boom")
+
+
+def test_simthread_logs_unhandled_exception(caplog):
+    thread = SimThread(ExplodingSolarSystem())
+
+    with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError, match="sim boom"):
+        thread.run()
+
+    assert "Unhandled exception in simulation thread" in caplog.text
+    assert "sim boom" in caplog.text


### PR DESCRIPTION
## Summary
- Add `crashlog.py` with rotating file logging under `HIGHFRONTIER_LOG_DIR` or `~/.highfrontier/logs`.
- Install stdlib `sys.excepthook`/`threading.excepthook` support and a helper for contextual crash logging.
- Log and re-raise unhandled `SimThread` exceptions so daemon simulation failures are visible.
- Configure crash logging around the `main.py` script entry point.

## Test Plan
- `PYTHONDONTWRITEBYTECODE=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/hermes/work/hfvenv/bin/python -m pytest -q tests/test_crashlog.py tests/test_simthread.py`
- `PYTHONDONTWRITEBYTECODE=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/hermes/work/hfvenv/bin/python -m pytest -q`
- `/home/hermes/work/hfvenv/bin/python -m compileall -q -x "(.git|__pycache__)" .`

## Risks/Notes
- Runtime behavior is unchanged except that unhandled exceptions are now written to a rotating log and re-raised.
- Intro/menu startup logging is intentionally left for the import-guard PR path to avoid mixing concerns.
