### PR TITLE
fix: harden world data and route initialization

### DIFF
--- a/company.py
+++ b/company.py
@@ -1764,7 +1764,7 @@ class base(firm):
 									transport_type = "ground transport"
 									endpoints = [other_base.base_name,self.base_name] #try to remove this if you get the opportunity FIXME
 									endpoint_links = [other_base,self]
-									trade_route = {"distance":distance[0],"transport_type":transport_type,"endpoints":endpoints,"endpoint_links":endpoint_links} #converting distance from list to float (has to be list see planet
+									trade_route = {"distance":distance[0],"transport_type":transport_type,"endpoints":endpoints,"endpoint_links":endpoint_links,"metadata":{"schema_version":1,"route_class":"surface-surface"}} #converting distance from list to float (has to be list see planet
 									self.trade_routes[other_base.base_name] = trade_route
 									other_base.trade_routes[self.base_name] = trade_route
 		else: #space station trade route
@@ -1781,7 +1781,7 @@ class base(firm):
 			transport_type = "space transport"
 			endpoints = [space_port.base_name,self.base_name] #try to remove this if you get the opportunity FIXME
 			endpoint_links = [space_port,self]
-			trade_route = {"distance":distance,"transport_type":transport_type,"endpoints":endpoints,"endpoint_links":endpoint_links} #converting distance from list to float (has to be list see planet
+			trade_route = {"distance":distance,"transport_type":transport_type,"endpoints":endpoints,"endpoint_links":endpoint_links,"metadata":{"schema_version":1,"route_class":"surface-orbit"}} #converting distance from list to float (has to be list see planet
 			self.trade_routes[space_port.base_name] = trade_route
 			space_port.trade_routes[self.base_name] = trade_route
 
@@ -2100,7 +2100,8 @@ class base_construction(firm):
 					transport_type = self.base_to_be_build_data["transport_type_to_origin"]
 					endpoints = [new_base.base_name,self.location.base_name] #try to remove this if you get the opportunity FIXME
 					endpoint_links = [new_base,self.location]
-					trade_route = {"distance":distance,"transport_type":transport_type,"endpoints":endpoints,"endpoint_links":endpoint_links} #converting distance from list to float (has to be list see planet
+					route_class = "surface-orbit" if transport_type == "space transport" else "surface-surface"
+					trade_route = {"distance":distance,"transport_type":transport_type,"endpoints":endpoints,"endpoint_links":endpoint_links,"metadata":{"schema_version":1,"route_class":route_class}} #converting distance from list to float (has to be list see planet
 					new_base.trade_routes[self.location.base_name] = trade_route
 					self.location.trade_routes[new_base.base_name] = trade_route
 

--- a/data/economy/trade resources.txt
+++ b/data/economy/trade resources.txt
@@ -18,3 +18,4 @@ ground transport	False	False	transportation	100	ton/km	False	NA	NA	NA
 space transport	False	False	transportation	100	ton/km	False	NA	NA	NA
 oxygen	True	True	manufacturing	5	ton	False	NA	NA	NA
 nitrogen	True	True	manufacturing	5	ton	False	NA	NA	NA
+terraforming	False	False	service	100	units	False	NA	NA	NA

--- a/solarsystem.py
+++ b/solarsystem.py
@@ -275,9 +275,9 @@ class solarsystem:
 #                    if random.randint(1,3) == 1:
                     if True:
                         start_up_name = technology + " "+ str(random.randint(1000,9999))
-                        size_chosen = random.randint(1, all_bases[home_city].population)
                         location_name = list(company_instance.home_cities.keys())[0]
                         location = company_instance.home_cities[location_name]
+                        size_chosen = random.randint(1, location.population)
                         company_instance.change_firm_size(
                                                location,
                                                size_chosen,

--- a/tests/test_company_initialization.py
+++ b/tests/test_company_initialization.py
@@ -1,0 +1,38 @@
+import random
+
+import global_variables
+from solarsystem import solarsystem
+
+
+def test_initial_bootstrap_firms_do_not_exceed_their_home_city_population():
+    random.seed(12345)
+    sol = solarsystem(global_variables.start_date, de_novo_initialization=True)
+
+    oversize_firms = []
+    for company_instance in sol.companies.values():
+        for firm_instance in company_instance.owned_firms.values():
+            if getattr(firm_instance, "technology_name", None) == "Base":
+                continue
+            location = getattr(firm_instance, "location", None)
+            if location is None or not hasattr(location, "population"):
+                continue
+            if firm_instance.size > location.population:
+                oversize_firms.append(
+                    (company_instance.name, firm_instance.name, firm_instance.size, location.population)
+                )
+
+    assert oversize_firms == []
+
+
+def test_company_database_integer_genes_stay_within_1_to_100():
+    random.seed(12345)
+    sol = solarsystem(global_variables.start_date, de_novo_initialization=True)
+
+    out_of_bounds = []
+    for company_instance in sol.companies.values():
+        for gene_name, gene_value in company_instance.company_database.items():
+            if isinstance(gene_value, int):
+                if not 1 <= gene_value <= 100:
+                    out_of_bounds.append((company_instance.name, gene_name, gene_value))
+
+    assert out_of_bounds == []

--- a/tests/test_economy_data.py
+++ b/tests/test_economy_data.py
@@ -1,0 +1,27 @@
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _trade_resources():
+    rows = (REPO_ROOT / "data" / "economy" / "trade resources.txt").read_text().splitlines()
+    return {row.split("\t")[0] for row in rows[2:] if row.strip()}
+
+
+def _technology_resources():
+    root = ET.parse(REPO_ROOT / "data" / "technology" / "technology.txt").getroot()
+    resources = set()
+    for process in root.findall(".//abstract_process_dict"):
+        for tag in ("input", "output"):
+            for resource in process.findall(tag):
+                if resource.text:
+                    resources.add(resource.text.strip())
+    return resources
+
+
+def test_all_technology_inputs_and_outputs_are_declared_trade_resources():
+    missing_resources = _technology_resources() - _trade_resources()
+
+    assert missing_resources == set()

--- a/tests/test_space_routes.py
+++ b/tests/test_space_routes.py
@@ -1,0 +1,44 @@
+import random
+
+import company
+import global_variables
+from solarsystem import solarsystem
+
+
+def _make_space_base(sol):
+    earth = sol.planets["earth"]
+    ground_base = next(iter(earth.bases.values()))
+    base_data = {
+        "eastern_loc": None,
+        "northern_loc": None,
+        "GDP_per_capita_in_dollars": ground_base.gdp_per_capita_in_dollars,
+        "population": 100,
+        "country": ground_base.original_country,
+    }
+    space_base = company.base(sol, "test orbit", earth, base_data, ground_base.owner)
+    earth.bases[space_base.base_name] = space_base
+    return earth, ground_base, space_base
+
+
+def test_space_base_has_space_terrain_and_no_mining():
+    sol = solarsystem(global_variables.start_date, de_novo_initialization=True)
+    earth, _, space_base = _make_space_base(sol)
+
+    assert space_base.terrain_type == "Space"
+    assert space_base.get_mining_opportunities(earth, "iron") == 0
+    assert space_base.get_mining_opportunities(earth, "food") == 0
+
+
+def test_space_trade_route_is_reciprocal_and_keeps_legacy_keys_with_metadata():
+    random.seed(12345)
+    sol = solarsystem(global_variables.start_date, de_novo_initialization=True)
+    _, _, space_base = _make_space_base(sol)
+
+    space_base.calculate_trade_routes(space_base.home_planet)
+    [(ground_name, route)] = list(space_base.trade_routes.items())
+    ground_route = space_base.home_planet.bases[ground_name].trade_routes[space_base.base_name]
+
+    assert ground_route is route
+    assert {"distance", "transport_type", "endpoints", "endpoint_links"} <= set(route)
+    assert route["metadata"]["schema_version"] == 1
+    assert route["metadata"]["route_class"] == "surface-orbit"


### PR DESCRIPTION
## Summary
- Fix bootstrap firm sizing to use the target company home city population instead of a stale loop variable.
- Add deterministic initialization/gene-bound regression coverage for company AI bootstrap data.
- Add economy data validation that every technology input/output is declared as a trade resource, and declare `terraforming` to match the existing technology output.
- Add tests for existing space-base behavior and add backward-compatible route metadata while preserving legacy route keys.

## Test Plan
- `PYTHONDONTWRITEBYTECODE=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/hermes/work/hfvenv/bin/python -m pytest -q tests/test_company_initialization.py tests/test_economy_data.py tests/test_space_routes.py`
- `PYTHONDONTWRITEBYTECODE=1 SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/hermes/work/hfvenv/bin/python -m pytest -q`
- `/home/hermes/work/hfvenv/bin/python -m compileall -q -x "(.git|__pycache__)" .`

## Risks/Notes
- This keeps route dict consumers backward-compatible by retaining existing keys and adding only optional metadata.
- `terraforming` is declared as a non-transportable/non-storable service to match current technology output without designing a new planet-effect system in this PR.
- The nuclear byproduct naming issue remains a separate follow-up because it needs focused generated-technology regression coverage.
