### PR TITLE
fix: validate company AI gene selection

### DIFF
--- a/company.py
+++ b/company.py
@@ -11,6 +11,13 @@ from PIL import Image, ImageChops
 import pygame
 
 
+def select_strategy(functions_to_choose_from, company_gene):
+	"""Map a 1..100 company AI gene to a one-based strategy table entry."""
+	if company_gene < 1 or company_gene > 100:
+		raise ValueError("company strategy genes must be between 1 and 100")
+	function_to_choose = int(math.ceil(len(functions_to_choose_from) * (company_gene / 100.0)))
+	return functions_to_choose_from[function_to_choose]
+
 
 class company:
 	"""
@@ -108,7 +115,10 @@ class company:
 			if global_variables.company_database_headers[headers] == "int":
 				if headers in list(model_company_database.keys()):
 					if standard_deviation == 0:
-						new_company_database[headers] = model_company_database[headers]
+						gene_value = model_company_database[headers]
+						if gene_value < 1 or gene_value > 100:
+							raise ValueError(headers + " must be between 1 and 100")
+						new_company_database[headers] = gene_value
 					else:
 						new_company_database[headers] = int(math.fabs(random.gauss(model_company_database[headers],standard_deviation)))
 						while 1 > new_company_database[headers] or new_company_database[headers] > 100: #to make the deviation correct, even at the ends. I wonder if this is a good idea
@@ -187,8 +197,7 @@ class company:
 		##############################################
 		if self.automation_dict["Start research firms"]:
 			functions_to_choose_from = global_variables.market_decisions.start_research_firms
-			function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.company_database["start_research_firms"] / 100.0)))
-			functions_to_choose_from[function_to_choose](self)
+			select_strategy(functions_to_choose_from, self.company_database["start_research_firms"])(self)
 
 
 
@@ -196,30 +205,26 @@ class company:
 		##############################################
 		if self.automation_dict["Commodities market (start commodity producing firms)"]:
 			functions_to_choose_from = global_variables.market_decisions.evaluate_commodities_market
-			function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.company_database["evaluate_commodities_market"] / 100.0)))
-			functions_to_choose_from[function_to_choose](self)
+			select_strategy(functions_to_choose_from, self.company_database["evaluate_commodities_market"])(self)
 
 		#check if nearby assets should be bought
 		##############################################
 		if self.automation_dict["Asset market (buy bases and firms)"]:
 			functions_to_choose_from = global_variables.market_decisions.evaluate_asset_market
-			function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.company_database["evaluate_asset_market"] / 100.0)))
-			functions_to_choose_from[function_to_choose](self)
+			select_strategy(functions_to_choose_from, self.company_database["evaluate_asset_market"])(self)
 
 
 		#check what decisions should be made on the tech market
 		##############################################
 		if self.automation_dict["Tech market (buy and sell technology)"]:
 			functions_to_choose_from = global_variables.market_decisions.evaluate_tech_market
-			function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.company_database["evaluate_tech_market"] / 100.0)))
-			functions_to_choose_from[function_to_choose](self)
+			select_strategy(functions_to_choose_from, self.company_database["evaluate_tech_market"])(self)
 
 		#check if any merchant companies should be started up
 		##############################################
 		if self.automation_dict["Transport market (start up merchant firms)"]:
 			functions_to_choose_from = global_variables.market_decisions.evaluate_intercity_trade_market
-			function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.company_database["evaluate_intercity_trade_market"] / 100.0)))
-			functions_to_choose_from[function_to_choose](self)
+			select_strategy(functions_to_choose_from, self.company_database["evaluate_intercity_trade_market"])(self)
 
 
 
@@ -227,8 +232,7 @@ class company:
 		##############################################
 		if self.automation_dict["Expand area of operation (search for new home cities)"]:
 			functions_to_choose_from = global_variables.market_decisions.evaluate_expansion_opportunities
-			function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.company_database["evaluate_expansion_opportunities"] / 100.0)))
-			functions_to_choose_from[function_to_choose](self)
+			select_strategy(functions_to_choose_from, self.company_database["evaluate_expansion_opportunities"])(self)
 
 
 
@@ -254,8 +258,7 @@ class company:
 		"""
 
 		functions_to_choose_from = global_variables.market_decisions.evaluate_firms
-		function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.company_database["evaluate_firms"] / 100.0)))
-		functions_to_choose_from[function_to_choose](self)
+		select_strategy(functions_to_choose_from, self.company_database["evaluate_firms"])(self)
 
 
 
@@ -267,8 +270,7 @@ class company:
 		to the number of entries in the database
 		"""
 		functions_to_choose_from = global_variables.market_decisions.pick_research
-		function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.company_database["pick_research"] / 100.0)))
-		functions_to_choose_from[function_to_choose](self)
+		select_strategy(functions_to_choose_from, self.company_database["pick_research"])(self)
 
 
 
@@ -838,8 +840,7 @@ class firm():
 		"""
 
 		functions_to_choose_from = global_variables.market_decisions.calculate_demand_reaction
-		function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.owner.company_database["calculate_demand_reaction"] / 100.0)))
-		functions_to_choose_from[function_to_choose](self)
+		select_strategy(functions_to_choose_from, self.owner.company_database["calculate_demand_reaction"])(self)
 
 
 
@@ -850,8 +851,7 @@ class firm():
 		to the number of entries in the databae
 		"""
 		functions_to_choose_from = global_variables.market_decisions.calculate_supply_reaction
-		function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.owner.company_database["calculate_supply_reaction"] / 100.0)))
-		functions_to_choose_from[function_to_choose](self)
+		select_strategy(functions_to_choose_from, self.owner.company_database["calculate_supply_reaction"])(self)
 
 
 
@@ -2321,8 +2321,7 @@ class merchant(tertiary):
 		"""
 
 		functions_to_choose_from = global_variables.market_decisions.calculate_intercity_demand
-		function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.owner.company_database["calculate_intercity_demand"] / 100.0)))
-		functions_to_choose_from[function_to_choose](self)
+		select_strategy(functions_to_choose_from, self.owner.company_database["calculate_intercity_demand"])(self)
 
 
 
@@ -2334,5 +2333,4 @@ class merchant(tertiary):
 		"""
 		pass
 		functions_to_choose_from = global_variables.market_decisions.calculate_intercity_supply
-		function_to_choose = int(math.ceil(len(functions_to_choose_from) * (self.owner.company_database["calculate_intercity_supply"] / 100.0)))
-		functions_to_choose_from[function_to_choose](self)
+		select_strategy(functions_to_choose_from, self.owner.company_database["calculate_intercity_supply"])(self)

--- a/tests/test_company_initialization.py
+++ b/tests/test_company_initialization.py
@@ -1,5 +1,8 @@
 import random
 
+import pytest
+
+import company as company_module
 import global_variables
 from solarsystem import solarsystem
 
@@ -36,3 +39,23 @@ def test_company_database_integer_genes_stay_within_1_to_100():
                     out_of_bounds.append((company_instance.name, gene_name, gene_value))
 
     assert out_of_bounds == []
+
+
+def test_model_company_database_rejects_integer_genes_outside_1_to_100():
+    company_instance = company_module.company.__new__(company_module.company)
+
+    with pytest.raises(ValueError, match="desired_gini_coefficent"):
+        company_instance.calculate_company_database(
+            {"desired_gini_coefficent": 101}, standard_deviation=0
+        )
+
+
+def test_strategy_selector_maps_company_genes_to_one_based_strategy_keys():
+    strategies = {1: "low", 2: "medium", 3: "high"}
+
+    assert company_module.select_strategy(strategies, 1) == "low"
+    assert company_module.select_strategy(strategies, 33) == "low"
+    assert company_module.select_strategy(strategies, 34) == "medium"
+    assert company_module.select_strategy(strategies, 66) == "medium"
+    assert company_module.select_strategy(strategies, 67) == "high"
+    assert company_module.select_strategy(strategies, 100) == "high"


### PR DESCRIPTION
## Summary
- add regression coverage for rejecting out-of-range company AI genes copied from model data
- add explicit strategy selector mapping coverage for 1..100 genes to one-based strategy tables
- centralize company/firm strategy selection through the validated selector

## Test Plan
- .venv/bin/python -m pytest tests/test_company_initialization.py::test_model_company_database_rejects_integer_genes_outside_1_to_100 -q
- .venv/bin/python -m pytest tests/test_company_initialization.py::test_strategy_selector_maps_company_genes_to_one_based_strategy_keys -q
- .venv/bin/python -m pytest tests/test_company_initialization.py -q
- .venv/bin/python -m pytest -q
- .venv/bin/python -m compileall -q -x "(.git|__pycache__|.venv)" .
