### PR TITLE
fix: validate technology resource data

### DIFF
--- a/technology.py
+++ b/technology.py
@@ -637,11 +637,11 @@ class Tree():
 				new_technology["input_output_dict"]["byproducts"]["carbondioxide"] = co2_emission
 
 
-			# rule 2: the radioactive waste from everything that has fission source as input is proportional to the coal input +/- X % randomness (where X is high, to reflect the many various fission technologies)
+			# rule 2: the radioactive waste from everything that has nuclear fuel as input is proportional to the nuclear fuel input +/- X % randomness (where X is high, to reflect the many various fission technologies)
 			percent_randomness = 0.8 # how many percent of ideal value, the final value can differ per resource - don't put more than 1.
-			if "fission source" in list(input_output_dict["input"].keys()):
-				fission_source_input = input_output_dict["input"]["fission source"]
-				radioactive_waste_emission = int(fission_source_input + ((random.random() - 0.5) * 2 * percent_randomness * fission_source_input))
+			if "nuclear fuel" in list(input_output_dict["input"].keys()):
+				nuclear_fuel_input = input_output_dict["input"]["nuclear fuel"]
+				radioactive_waste_emission = int(nuclear_fuel_input + ((random.random() - 0.5) * 2 * percent_randomness * nuclear_fuel_input))
 				new_technology["input_output_dict"]["byproducts"]["radioactive waste"] = radioactive_waste_emission
 
 			new_technology["known_by"] = {}

--- a/tests/test_economy_data.py
+++ b/tests/test_economy_data.py
@@ -1,8 +1,16 @@
+import random
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from technology import Tree
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Technology input/output entries should normally name stockpiled/traded
+# resources. Keep explicit non-stockpiled gameplay effects here if technology
+# data ever needs an effect output that should not be listed in trade resources.
+NON_STOCKPILED_TECHNOLOGY_EFFECTS = set()
 
 
 def _trade_resources():
@@ -21,7 +29,45 @@ def _technology_resources():
     return resources
 
 
-def test_all_technology_inputs_and_outputs_are_declared_trade_resources():
-    missing_resources = _technology_resources() - _trade_resources()
+class _OneSubjectCoreTree:
+    def __init__(self, subject):
+        self.subject_list = [subject]
+
+    def calculate_technology_web(self, _radial_distance):
+        return {self.subject_list[0]["technology_name"]: 0}
+
+
+class _FakeSolarSystem:
+    message_printing = {"debugging": False}
+    messages = []
+
+
+def test_all_technology_inputs_and_outputs_are_trade_resources_or_documented_effects():
+    missing_resources = (
+        _technology_resources()
+        - _trade_resources()
+        - NON_STOCKPILED_TECHNOLOGY_EFFECTS
+    )
 
     assert missing_resources == set()
+
+
+def test_nuclear_fuel_technologies_generate_radioactive_waste_byproduct():
+    subject = {
+        "technology_name": "nuclear power",
+        "productivity_multiplier": 1,
+        "abstract_process_dict": {"input": ["nuclear fuel"], "output": ["power"]},
+        "co_descriptors": {
+            "connecting_word": [],
+            "adjective": ["test"],
+            "noun": ["reactor"],
+        },
+        "importance_function": None,
+    }
+    random.seed(0)
+    tree = Tree(_OneSubjectCoreTree(subject), _FakeSolarSystem())
+
+    technology_name = tree.new_iteration((5, 45))
+    byproducts = tree.vertex_dict[technology_name]["input_output_dict"]["byproducts"]
+
+    assert "radioactive waste" in byproducts


### PR DESCRIPTION
## Summary
- extend technology economy data validation to allow explicitly documented non-stockpiled effects
- add regression coverage for nuclear-fuel technologies producing radioactive waste
- update byproduct generation to key off the data's `nuclear fuel` resource instead of the obsolete `fission source` name

## Test Plan
- .venv/bin/pytest tests/test_economy_data.py::test_nuclear_fuel_technologies_generate_radioactive_waste_byproduct -q (RED before fix: failed with `AssertionError: assert 'radioactive waste' in {}`)
- .venv/bin/pytest tests/test_economy_data.py -q
- .venv/bin/pytest -q
- python3 -m compileall .
