### PR TITLE
Modernize save handling and runtime foundations

### DIFF
--- a/company.py
+++ b/company.py
@@ -679,6 +679,7 @@ class company:
 					new_firm.size = size
 					new_firm.last_consumption_date = self.solar_system_object_link.current_date
 					self.owned_firms[firm_name] = new_firm
+					self.solar_system_object_link.record_telemetry("firm_starts")
 
 
 				#if it is not we search for the process requested
@@ -714,6 +715,7 @@ class company:
 					new_firm.size = size
 					new_firm.last_consumption_date = self.solar_system_object_link.current_date
 					self.owned_firms[firm_name] = new_firm
+					self.solar_system_object_link.record_telemetry("firm_starts")
 
 					#checking input_output_dict FIXME this check can perhaps be omitted
 					for resource in new_firm.input_output_dict["input"]:
@@ -1144,6 +1146,7 @@ class firm():
 			transaction_report["seller"].accounting.append(transaction_report)
 			transaction_report["buyer"].accounting.append(transaction_report)
 			market["transactions"][resource].append(transaction_report)
+			self.solar_system_object_link.record_telemetry("transactions")
 
 			if transaction_report["quantity"] < 0:
 				#print

--- a/company.py
+++ b/company.py
@@ -9,6 +9,7 @@ import time
 
 from PIL import Image, ImageChops
 import pygame
+from paths import asset_path, data_path
 
 
 def select_strategy(functions_to_choose_from, company_gene):
@@ -94,7 +95,7 @@ class company:
 
 		try: global_variables.company_database_headers
 		except:
-			with open(os.path.join("data","economy","companies.txt")) as company_database_headers_file:
+			with open(data_path("economy","companies.txt")) as company_database_headers_file:
 				company_database_headers = company_database_headers_file.readline()
 				company_database_headers = company_database_headers.split("\t")
 				explanation = company_database_headers_file.readline()
@@ -146,7 +147,7 @@ class company:
 		if self.picture_file != None:
 			file_name_and_path = self.picture_file
 		else:
-			company_base_dir = os.path.join("images","company")
+			company_base_dir = asset_path("images","company")
 			file_list = []
 			for files in os.walk(company_base_dir):
 				for found_file in files[2]:
@@ -161,8 +162,8 @@ class company:
 			else:
 				my_pick = random.randrange(0,number_of_files_to_pick_from)
 				file_name = file_list[my_pick]
-				file_name_and_path = os.path.join(company_base_dir,file_name)
-			self.picture_file = file_name_and_path
+				file_name_and_path = company_base_dir / file_name
+			self.picture_file = str(file_name_and_path)
 
 		image = Image.open(file_name_and_path)
 
@@ -532,7 +533,7 @@ class company:
 			last_words = []
 
 			for stock_exchange in stock_exchanges:
-				file_name = os.path.join("data","company_data",stock_exchange)
+				file_name = data_path("company_data",stock_exchange)
 
 				file = open(file_name)
 				raw_read = file.readlines()
@@ -791,7 +792,7 @@ class firm():
 		if self.picture_file != None:
 			file_name_and_path = self.picture_file
 		else:
-			company_base_dir = os.path.join("images","firm")
+			company_base_dir = asset_path("images","firm")
 			file_list = []
 			for files in os.walk(company_base_dir):
 				for found_file in files[2]:
@@ -806,8 +807,8 @@ class firm():
 			else:
 				my_pick = random.randrange(0,number_of_files_to_pick_from)
 				file_name = file_list[my_pick]
-				file_name_and_path = os.path.join(company_base_dir,file_name)
-			self.picture_file = file_name_and_path
+				file_name_and_path = company_base_dir / file_name
+			self.picture_file = str(file_name_and_path)
 
 		image = Image.open(file_name_and_path)
 
@@ -1662,12 +1663,12 @@ class base(firm):
 			file_name_and_path = self.picture_file
 		else:
 			if self.position_coordinate == (None, None):
-				planet_base_dir = os.path.join("images","base","space")
+				planet_base_dir = asset_path("images","base","space")
 			else:
-				if os.access(os.path.join("images","base",self.home_planet.planet_name),os.R_OK):
-					planet_base_dir = os.path.join("images","base",self.home_planet.planet_name)
+				if os.access(asset_path("images","base",self.home_planet.planet_name),os.R_OK):
+					planet_base_dir = asset_path("images","base",self.home_planet.planet_name)
 				else:
-					planet_base_dir = os.path.join("images","base","other")
+					planet_base_dir = asset_path("images","base","other")
 
 			file_name = self.base_name + ".jpg"
 			file_list = []
@@ -1686,7 +1687,7 @@ class base(firm):
 					size = "large_random"
 				else:
 					size = "medium_random"
-				files_to_choose_from = os.listdir(os.path.join(planet_base_dir,size))
+				files_to_choose_from = os.listdir(planet_base_dir / size)
 				files_to_choose_from_filtered = []
 				for file_to_choose_from in files_to_choose_from:
 					if file_to_choose_from.find(".jpg") != -1:
@@ -1700,8 +1701,8 @@ class base(firm):
 				else:
 					my_pick = random.randrange(0,number_of_files_to_pick_from)
 					file_name = files_to_choose_from_filtered[my_pick]
-					file_name_and_path = os.path.join(planet_base_dir,size,file_name)
-			self.picture_file = file_name_and_path
+					file_name_and_path = planet_base_dir / size / file_name
+			self.picture_file = str(file_name_and_path)
 
 		image = Image.open(file_name_and_path)
 

--- a/docs/overnight-roadmap-2026-06-11.md
+++ b/docs/overnight-roadmap-2026-06-11.md
@@ -1,0 +1,152 @@
+# High Frontier overnight roadmap — 2026-06-11
+
+This document records the Stage 03 review-gate outcome for branch `wave/2026-06-11-save-path-sim-foundation` and turns the 2026-06-10 roadmap into an ordered follow-up plan. It is intentionally conservative: preserve old saves, keep the retro Pygame application as canonical, and keep gameplay expansion out of this wave.
+
+## Completed in this wave
+
+### Save/load hardening
+
+- Added `savegame.py` as the central save wrapper/name-validation module.
+- New saves are pickled dictionaries with explicit metadata:
+  - `format = highfrontier-save`
+  - `version = 1`
+  - `payload_type = solarsystem-pickle`
+  - `payload = <legacy solarsystem object graph>`
+- Legacy raw-pickle loads are still accepted by `unwrap_save_payload()`.
+- Empty, corrupt, unsupported-version, unsupported-payload, and invalid-payload saves now fail before mutating the currently running `solarsystem` instance.
+- Save writes continue to use the existing temporary-file plus atomic-replace path, now wrapping the payload before pickling.
+- GUI-adjacent save/load edits stayed narrow:
+  - save names are validated before saving/loading;
+  - invalid/temp/reserved save entries are filtered from the load menu;
+  - rejected names print a short error and do not attempt to load or save.
+
+### Runtime paths and packaging metadata
+
+- Added/used repository-relative path helpers for high-risk asset/data callers so selected modules can run from a non-repository current working directory.
+- Added `pyproject.toml` with build metadata and runtime/dev dependencies only.
+- No console scripts or forced entry points were added.
+
+### Ocempgui cleanup
+
+- Removed stale commented Ocempgui import remnants from active code files.
+- Did not rewrite functioning widgets or perform broad GUI decomposition.
+- Historical roadmap/docs may keep Ocempgui mentions as context.
+
+### Simulation test floor and telemetry skeleton
+
+- Added deterministic/full-initialization coverage without fixed-count snapshots: the test now compares stable aggregates across two same-seed initializations and separately checks broad core-economy invariants.
+- Added xfail intended-behavior tests that document known bugs without changing behavior:
+  - intercity trade profit sign;
+  - research desired-ratio comparison.
+- Added a telemetry skeleton on `solarsystem` with zeroed keys for stockouts, zero-stock bases, transactions, firm starts/closes, and bankruptcies.
+- Instrumented only two low-risk central counters in this wave:
+  - `firm_starts`;
+  - `transactions`.
+
+### Review-gate cleanup
+
+- Reviewed diff against `origin/master` for scope compliance.
+- Confirmed no browser/frontend/Pygame-in-browser/HTML work.
+- Confirmed no broad `gui.py` decomposition.
+- Confirmed no sections 6/7 gameplay expansion.
+- Confirmed no production fix for the intercity trade profit sign.
+- Reworked the initial broad exact-count snapshot into less brittle determinism/invariant tests.
+
+## Partially completed / not completed
+
+- Save compatibility is preserved as much as practical for raw pickle payloads, but raw pickle remains trusted-only and fragile across module/class refactors.
+- Save/load errors are safer, but player-facing UX is still just console output in the narrow GUI call sites touched here.
+- Path modernization is partial. Several modules still contain relative paths or import-time side effects that should be handled in focused branches.
+- Telemetry currently stores counters only. There is no telemetry UI, export, persistence policy, or complete instrumentation for all declared keys.
+- Crash logging, CI workflow upgrades, linting, and richer headless GUI smoke tests were not part of this wave.
+- No `main()`/entry-point cleanup was attempted because clean startup boundaries are not yet proven safe.
+- No gameplay economics/resource-chain changes were implemented.
+
+## Explicitly postponed GUI/frontend section — options only, no action in this wave
+
+The retro Pygame frontend remains the canonical UI. Do not start browser/web/frontend/Pygame-in-browser/HTML work from this branch.
+
+Future options, in safe order:
+
+1. `gui-save-load-ux` branch
+   - Keep scope limited to save/load dialogs.
+   - Convert current console-only invalid-save messages into in-game messages or a small modal using existing widgets.
+   - Add dummy-SDL tests around filename validation and load-list filtering.
+
+2. `gui-component-smoke-tests` branch
+   - Add focused tests for `gui_components.fast_list`, buttons, toggles, and entry widgets.
+   - Avoid pixel-perfect snapshots unless there is a small stable surface and a clear reason.
+   - Fix obvious widget bugs only when a test reproduces them first.
+
+3. `gui-pure-helper-extraction` branch
+   - Extract small pure calculations from `gui.py` only when tests can pin current behavior.
+   - Good candidates: base-construction cost/route calculations, list filtering, layout constants.
+   - Do not split `gui.py` broadly or rename large classes in one pass.
+
+4. Future frontend experiment branch, much later
+   - Only after simulation commands/view models are separated from rendering.
+   - Keep it explicitly experimental and separate from core save/simulation PRs.
+   - Do not replace the Pygame UI until save compatibility and core tests are strong.
+
+## Explicitly postponed sections 6/7 gameplay section
+
+No sections 6/7 gameplay expansion was implemented in this wave. Specifically postponed:
+
+- no new resource chains;
+- no new base-demand goods;
+- no orbital-route redesign;
+- no first-class route graph/pathfinding;
+- no orbital settlement/station AI;
+- no space-settlement automation.
+
+Future section 6 economics options, after the current safe-foundation work lands:
+
+1. `data-validation-resources` branch
+   - Add tests that every technology input/output/byproduct exists as a declared trade resource or documented non-stockpiled effect.
+   - Document current mismatches such as terraforming and nuclear byproduct naming before changing data.
+
+2. `economy-naming-fixes` branch
+   - Fix narrow data/name mismatches with tests.
+   - Avoid adding new chains in the same PR.
+
+3. `resource-chain-prototypes` branch
+   - Only after validation is green.
+   - Add one small resource chain at a time, with initialization and market tests.
+
+Future section 7 space/base/route options, after GUI and simulation seams are safer:
+
+1. `space-base-current-behavior-tests` branch
+   - Test existing `(None, None)` space-base behavior, mining restrictions, and clickable station areas.
+
+2. `route-metadata-compat` branch
+   - Add optional route metadata fields without changing existing consumers.
+   - Preserve old save payloads by defaulting missing metadata on load/use.
+
+3. `route-graph-spike` branch
+   - Throwaway or draft-only spike for pathfinding/route graph design.
+   - Do not merge until old route behavior has compatibility tests.
+
+4. `orbital-visualization-tests` branch
+   - Add fixtures/tests before changing how orbital routes are drawn.
+
+## Next recommended branch order
+
+1. Open a PR for `wave/2026-06-11-save-path-sim-foundation` after final local checks are green.
+2. `ci-headless-compileall` — add/adjust CI to run dummy-SDL pytest and compileall on supported Python versions.
+3. `crashlog-thread-hooks` — add top-level crash/thread logging without changing gameplay.
+4. `intro-main-guard-and-paths` — make import/startup boundaries safer and continue path modernization in small slices.
+5. `save-load-ux` — improve player-facing save/load error messages using existing widgets only.
+6. `simulation-bug-regressions` — convert the current strict xfail tests into fixes one bug at a time, starting with intercity trade sign or research ratio, each with TDD.
+7. `data-validation-resources` — add section 6 validation tests before any resource-chain changes.
+8. `space-base-current-behavior-tests` — add section 7 tests before any route/orbital redesign.
+
+## Acceptance checks for this branch
+
+Required before final handoff:
+
+```bash
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 .venv/bin/python -m pytest -q
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 .venv/bin/python -m compileall -q -x '(.git|__pycache__|.venv|venv)' .
+```
+
+Expected status: pytest passes with the known strict xfails for intentionally documented-but-unfixed behavior; compileall exits 0.

--- a/gui.py
+++ b/gui.py
@@ -11,6 +11,7 @@ import primitives
 import gui_components
 import random
 import time
+from savegame import SaveNameError, list_savegames, savegame_path
 
 from solarsystem import solarsystem
 from display import Display, raise_not_implemented_display, Direction
@@ -1326,7 +1327,12 @@ class file_window():
             self.distribute_click_to_subwindow.receive_click(event)
             if event.button == 3:
                 if self.position == "Load menu":
-                    self.solar_system_object_link.load_solar_system(os.path.join("savegames",self.distribute_click_to_subwindow.selected))
+                    try:
+                        filename = savegame_path("savegames", self.distribute_click_to_subwindow.selected)
+                    except SaveNameError as error:
+                        print(f"Invalid savegame name: {error}")
+                        return
+                    self.solar_system_object_link.load_solar_system(filename)
 
 
 
@@ -1370,13 +1376,18 @@ class file_window():
 
     def effectuate_save(self,label,function_parameter):
         save_game_name = self.button_instances_now["Name box"].text
-        self.solar_system_object_link.save_solar_system(os.path.join("savegames",save_game_name))
+        try:
+            filename = savegame_path("savegames", save_game_name)
+        except SaveNameError as error:
+            print(f"Invalid savegame name: {error}")
+            return
+        self.solar_system_object_link.save_solar_system(filename)
         self.create()
 
 
     def select_game_to_load(self, label, function_parameter):
         self.position = "Load menu"
-        load_window = gui_components.fast_list(self.action_surface, os.listdir("savegames"), rect = self.rect)
+        load_window = gui_components.fast_list(self.action_surface, list_savegames("savegames"), rect = self.rect)
         self.distribute_click_to_subwindow = load_window
 
 

--- a/gui_components.py
+++ b/gui_components.py
@@ -1,7 +1,4 @@
 import math
-#from ocempgui.widgets.Constants import *
-#from ocempgui.object import BaseObject
-#from ocempgui.widgets import *
 import global_variables
 import pygame
 import primitives

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import gui
 import random
 import importlib
 import crashlog
+from paths import asset_path
 
 
 
@@ -35,7 +36,7 @@ class Game:
             window = pygame.display.set_mode(window_size,FULLSCREEN)
         else:
             window = pygame.display.set_mode(window_size)
-        icon = pygame.image.load(os.path.join("images","window_icon.png"))
+        icon = pygame.image.load(asset_path("images","window_icon.png"))
         pygame.display.set_icon(icon)
         pygame.mouse.set_cursor(*pygame.cursors.arrow)
         #initializing the world - depends on if a previous game should be loaded

--- a/planet.py
+++ b/planet.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pygame, sys,os
 from pygame.locals import *
-#from ocempgui.widgets from PIL import ImageLabel
 from PIL import Image, ImageChops, ImageOps, ImageFile,ImageFilter,ImageEnhance
 import math
 import subprocess
@@ -13,6 +12,7 @@ import os
 import global_variables
 import company
 import random
+from paths import asset_path, data_path
 
 from pyproj import Transformer
 import numpy as np
@@ -38,7 +38,7 @@ class planet:
         self.current_base = None
         self.planet_name = planet_name
         self.name = planet_name
-        self.surface_file_name = os.path.join("images","planet",planet_file_name)
+        self.surface_file_name = str(asset_path("images","planet",planet_file_name))
         self.projection_scaling=45
         self.eastern_inclination = 0
         self.northern_inclination = 0
@@ -140,7 +140,7 @@ class planet:
 
 
     def read_pre_base_file(self,planet_name):
-        data_file_name = os.path.join("data","base_data",str(str(planet_name) + ".txt"))
+        data_file_name = data_path("base_data",str(str(planet_name) + ".txt"))
 
 
 
@@ -300,7 +300,7 @@ class planet:
         if os.access(self.surface_file_name,os.R_OK):
             image = Image.open(self.surface_file_name)
         else:
-            image = Image.open(os.path.join("images","planet","placeholder.jpg"))
+            image = Image.open(asset_path("images","planet","placeholder.jpg"))
 
         self.projection_dim = (self.projection_scaling,self.projection_scaling)
 
@@ -352,7 +352,7 @@ class planet:
         try: self.topo_image
         except AttributeError:
             #test if a pre-calculated topo-file exists
-            topo_file_name_and_path = os.path.join("images","planet","topo",str(self.planet_name + ".png"))
+            topo_file_name_and_path = asset_path("images","planet","topo",str(self.planet_name + ".png"))
             if os.access(topo_file_name_and_path,os.R_OK):
                 self.topo_image = Image.open(topo_file_name_and_path)
                 #print "topo file does not exist for " + str(self.planet_name) + " - all ok"
@@ -750,7 +750,7 @@ class planet:
         #try to find the proper non-renewable resource map
         try: self.resource_maps[resource_type]
         except:
-            resource_file_name_and_path = os.path.join("images","planet","nonrenewable materials map",resource_type,str(self.planet_name + ".png"))
+            resource_file_name_and_path = asset_path("images","planet","nonrenewable materials map",resource_type,str(self.planet_name + ".png"))
             if os.access(resource_file_name_and_path,os.R_OK):
                 resource_map_image = Image.open(resource_file_name_and_path)
                 #print "resource file " + str(resource_type) + " does exist for " + str(self.planet_name) + " - all ok"
@@ -1026,7 +1026,7 @@ class planet:
         if self.planet_display_mode not in ["visible light","trade network"]:
             try: self.heat_bar
             except:
-                self.heat_bar = pygame.image.load(os.path.join("images","heat_bar.png"))
+                self.heat_bar = pygame.image.load(asset_path("images","heat_bar.png"))
             else:
                 surface.blit(self.heat_bar,(0,global_variables.window_size[1]-320))
 
@@ -1413,7 +1413,7 @@ class planet:
 
         hit_locations = []
 
-        blast_surface = pygame.image.load(os.path.join("images","blast.png"))
+        blast_surface = pygame.image.load(asset_path("images","blast.png"))
         ratio = 0.25 *(float(per_hit_intensity) / 100.0) * (float(self.projection_scaling) / 360.0) * (self.solar_system_object_link.planets["earth"].planet_diameter_km / float(self.planet_diameter_km))
 #        print "ratio " + str(ratio)
         large_blast_surface = pygame.transform.scale(blast_surface, (int(blast_surface.get_width() * ratio / 2), int(blast_surface.get_height() * ratio / 2)))

--- a/primitives.py
+++ b/primitives.py
@@ -1,8 +1,6 @@
 import pygame
 import global_variables
 import datetime
-#from ocempgui.widgets import *
-#from ocempgui.widgets.Constants import *
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "highfrontier"
+version = "0.1.0"
+description = "Legacy Pygame space-economy simulation"
+requires-python = ">=3.10"
+dependencies = [
+    "numpy",
+    "pillow",
+    "pygame",
+    "pyproj",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]

--- a/savegame.py
+++ b/savegame.py
@@ -1,0 +1,122 @@
+"""Savegame validation and wrapper helpers for High Frontier."""
+
+import datetime
+import os
+import pickle
+
+SAVE_FORMAT = "highfrontier-save"
+SAVE_VERSION = 1
+PAYLOAD_TYPE = "solarsystem-pickle"
+
+
+class SaveNameError(ValueError):
+    """Raised when a user supplied savegame name is unsafe."""
+
+
+class SaveFormatError(ValueError):
+    """Raised when a savegame file cannot be decoded safely."""
+
+
+def validate_save_name(name):
+    """Return a stripped save name, or raise if it is unsafe."""
+    if not isinstance(name, str):
+        raise SaveNameError("Savegame name must be text")
+
+    save_name = name.strip()
+    if not save_name:
+        raise SaveNameError("Savegame name cannot be empty")
+    if os.path.isabs(save_name):
+        raise SaveNameError("Savegame name cannot be an absolute path")
+    if "/" in save_name or "\\" in save_name:
+        raise SaveNameError("Savegame name cannot contain path separators")
+    if save_name in {".", ".."}:
+        raise SaveNameError("Savegame name cannot be '.' or '..'")
+    if save_name == "emptyfile":
+        raise SaveNameError("Savegame name 'emptyfile' is reserved")
+    if save_name.lower().endswith(".tmp"):
+        raise SaveNameError("Temporary savegame files cannot be selected")
+
+    return save_name
+
+
+def savegame_path(save_dir, name):
+    """Return the path for a validated savegame name inside save_dir."""
+    return os.path.join(os.fspath(save_dir), validate_save_name(name))
+
+
+def list_savegames(save_dir):
+    """List selectable savegames, excluding temp/reserved/invalid entries."""
+    save_dir = os.fspath(save_dir)
+    if not os.path.isdir(save_dir):
+        return []
+
+    savegames = []
+    for entry in os.listdir(save_dir):
+        try:
+            save_name = validate_save_name(entry)
+        except SaveNameError:
+            continue
+        if not os.path.isfile(os.path.join(save_dir, save_name)):
+            continue
+        savegames.append(save_name)
+    return sorted(savegames)
+
+
+def make_save_wrapper(payload, created_at=None):
+    """Wrap a solarsystem payload with explicit save format metadata."""
+    if created_at is None:
+        created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    return {
+        "format": SAVE_FORMAT,
+        "version": SAVE_VERSION,
+        "created_at": created_at,
+        "payload_type": PAYLOAD_TYPE,
+        "payload": payload,
+    }
+
+
+def unwrap_save_payload(saved_object):
+    """Return the solarsystem object from a wrapper or legacy raw pickle."""
+    if isinstance(saved_object, dict) and "format" in saved_object:
+        save_format = saved_object.get("format")
+        if save_format != SAVE_FORMAT:
+            raise SaveFormatError(f"Unsupported savegame format: {save_format!r}")
+
+        version = saved_object.get("version")
+        if version != SAVE_VERSION:
+            raise SaveFormatError(
+                f"Unsupported savegame version: {version!r}; supported version is {SAVE_VERSION}"
+            )
+
+        payload_type = saved_object.get("payload_type")
+        if payload_type != PAYLOAD_TYPE:
+            raise SaveFormatError(f"Unsupported savegame payload type: {payload_type!r}")
+
+        if "payload" not in saved_object:
+            raise SaveFormatError("Savegame wrapper is missing payload")
+        return saved_object["payload"]
+
+    return saved_object
+
+
+def load_payload(filename):
+    """Load and unwrap a savegame payload from a pickle file."""
+    filename = os.fspath(filename)
+    try:
+        with open(filename, "rb") as save_file:
+            saved_object = pickle.load(save_file)
+    except EOFError as exc:
+        raise SaveFormatError(f"Savegame file is empty or truncated: {filename}") from exc
+    except pickle.UnpicklingError as exc:
+        raise SaveFormatError(f"Savegame file could not be unpickled: {filename}") from exc
+    except SaveFormatError:
+        raise
+    except Exception as exc:
+        raise SaveFormatError(f"Savegame file could not be loaded: {filename}: {exc}") from exc
+
+    return unwrap_save_payload(saved_object)
+
+
+def load_named_payload(save_dir, name):
+    """Validate a save name, then load its payload from save_dir."""
+    return load_payload(savegame_path(save_dir, name))

--- a/solarsystem.py
+++ b/solarsystem.py
@@ -13,6 +13,7 @@ import global_variables
 import primitives
 import technology
 import pickle
+from savegame import SaveFormatError, load_payload, make_save_wrapper
 from display import Display
 sys.setrecursionlimit(10000)
 
@@ -386,14 +387,14 @@ class solarsystem:
               self.simThread.join()  # Wait for the simulation thread to finish
               del self.simThread  # Delete the thread reference
               with open(tmp_filename, "wb") as file:
-                  pickle.dump(self, file)
+                  pickle.dump(make_save_wrapper(self), file)
                   file.flush()
                   os.fsync(file.fileno())
               os.replace(tmp_filename, filename)
               self.launchThread()
           else:
               with open(tmp_filename, "wb") as file:
-                  pickle.dump(self, file)
+                  pickle.dump(make_save_wrapper(self), file)
                   file.flush()
                   os.fsync(file.fileno())
               os.replace(tmp_filename, filename)
@@ -440,30 +441,25 @@ class solarsystem:
         """
         Function that loads the solar system
         """
-        try:
-            with open(filename, "rb") as file:
-                new_solar_system = pickle.load(file)
-        except EOFError as e:
-            print_dict = {"text": f"Un-loadable file: {filename} - no load performed", "type": "general gameplay info"}
-            error_message = str(e)
-            print(error_message)
-            raise Exception(f"An EOFError of type: {error_message} was found")
-        except Exception as e:
-            error_message = str(e)
-            print(error_message)
-            raise Exception(f"An error of type: {error_message} was found")
+        new_solar_system = load_payload(filename)
+        if not hasattr(new_solar_system, "planets") or not hasattr(new_solar_system, "companies"):
+            raise SaveFormatError("Savegame payload is not a solarsystem")
+
         #here we de-stringify the resource maps and other known planet images
-        for planet_instance in list(new_solar_system.planets.values()):
-            for known_planet_image in KNOWN_PLANET_IMAGES:
-                if hasattr(planet_instance, known_planet_image):
-                    image_parts = getattr(planet_instance, known_planet_image)
-                    image = _deserialize_pil_image(image_parts)
-                    setattr(planet_instance, known_planet_image, image)
-            if planet_instance.resource_maps != {}:
-                for resource in planet_instance.resource_maps:
-                    image_parts = planet_instance.resource_maps[resource]
-                    image = _deserialize_pil_image(image_parts)
-                    planet_instance.resource_maps[resource] = image
+        try:
+            for planet_instance in list(new_solar_system.planets.values()):
+                for known_planet_image in KNOWN_PLANET_IMAGES:
+                    if hasattr(planet_instance, known_planet_image):
+                        image_parts = getattr(planet_instance, known_planet_image)
+                        image = _deserialize_pil_image(image_parts)
+                        setattr(planet_instance, known_planet_image, image)
+                if planet_instance.resource_maps != {}:
+                    for resource in planet_instance.resource_maps:
+                        image_parts = planet_instance.resource_maps[resource]
+                        image = _deserialize_pil_image(image_parts)
+                        planet_instance.resource_maps[resource] = image
+        except Exception as exc:
+            raise SaveFormatError(f"Savegame payload could not be restored: {exc}") from exc
         #inserting all variables in self
         self.__dict__.clear()
         self.__dict__.update(new_solar_system.__dict__)

--- a/solarsystem.py
+++ b/solarsystem.py
@@ -15,6 +15,7 @@ import technology
 import pickle
 from savegame import SaveFormatError, load_payload, make_save_wrapper
 from display import Display
+from paths import data_path
 sys.setrecursionlimit(10000)
 
 KNOWN_PLANET_IMAGES = ["wet_areas", "topo_image"]
@@ -148,8 +149,8 @@ class solarsystem:
                                 "mining":False
                                 }
             # importing the trade resource text and the mineral_resources
-            if os.access(os.path.join("data","economy","trade resources.txt"),os.R_OK):
-                data_file_name = os.path.join("data","economy","trade resources.txt")
+            data_file_name = data_path("economy","trade resources.txt")
+            if os.access(data_file_name,os.R_OK):
                 trade_resources = primitives.import_datasheet(data_file_name)
                 mineral_resources = []
                 for resource_name in trade_resources:
@@ -188,7 +189,7 @@ class solarsystem:
         del self.companies[companyName]
 
     def initialize_planets(self) -> dict[str, planet.planet]:
-        data_file_name = os.path.join("data","planets.txt")
+        data_file_name = data_path("planets.txt")
         read_planet_database = primitives.import_datasheet(data_file_name)
         planet_database = {}
         for planet_name in read_planet_database:
@@ -216,7 +217,7 @@ class solarsystem:
                 country_GNP = base_to_GNP_list[base] + country_GNP
             country_to_GNP_list[country] = country_GNP
         ### Start up countries from companies.txt in data/economy
-        data_file_name = os.path.join("data","economy","companies.txt")
+        data_file_name = data_path("economy","companies.txt")
         read_company_database = primitives.import_datasheet(data_file_name)
         random_companyName = random.choice(list(read_company_database.keys()))
         for key in read_company_database[random_companyName]:

--- a/solarsystem.py
+++ b/solarsystem.py
@@ -19,6 +19,18 @@ from paths import data_path
 sys.setrecursionlimit(10000)
 
 KNOWN_PLANET_IMAGES = ["wet_areas", "topo_image"]
+TELEMETRY_KEYS = (
+    "stockouts",
+    "zero_stock_bases",
+    "transactions",
+    "firm_starts",
+    "firm_closes",
+    "bankruptcies",
+)
+
+
+def default_telemetry():
+    return {key: 0 for key in TELEMETRY_KEYS}
 
 
 def _serialize_pil_image(image):
@@ -50,6 +62,17 @@ class solarsystem:
         else:
             assert isinstance(value, Display)
         self._display_mode = value
+
+
+    def reset_telemetry(self):
+        self.telemetry = default_telemetry()
+
+
+    def record_telemetry(self, key, amount=1):
+        if not hasattr(self, "telemetry"):
+            self.reset_telemetry()
+        self.telemetry.setdefault(key, 0)
+        self.telemetry[key] = self.telemetry[key] + amount
 
 
     def launchThread(self):
@@ -138,6 +161,7 @@ class solarsystem:
             self.build_base_mode = False #a variable that specifies if a click on the map translates into building a base
             self.building_base = None #a link to the building base in build_base_mode - necessary for interplanetary builds
             self.messages = []
+            self.telemetry = default_telemetry()
             self.message_printing = {"general gameplay info":True,
                                 "general company info":True,
                                 "tech discovery":False,
@@ -180,6 +204,7 @@ class solarsystem:
             print("initializing companies")
             self.companies = self.initialize_companies()
             print("done initializing companies")
+            self.reset_telemetry()
             self.current_planet = self.planets["sun"]
 
     def close_company(self,companyName):
@@ -462,6 +487,11 @@ class solarsystem:
         except Exception as exc:
             raise SaveFormatError(f"Savegame payload could not be restored: {exc}") from exc
         #inserting all variables in self
+        if not hasattr(new_solar_system, "telemetry"):
+            new_solar_system.telemetry = default_telemetry()
+        else:
+            for telemetry_key in TELEMETRY_KEYS:
+                new_solar_system.telemetry.setdefault(telemetry_key, 0)
         self.__dict__.clear()
         self.__dict__.update(new_solar_system.__dict__)
         #updating all solar_system_object_links (this is actually rather weird that it has to be done)

--- a/technology.py
+++ b/technology.py
@@ -7,6 +7,7 @@ from xml.dom import minidom
 import os
 import global_variables
 import primitives
+from paths import data_path
 
 
 
@@ -779,7 +780,7 @@ class Backbone_Tree(Tree):
 
 		self.subject_list = []
 
-		self.import_core(os.path.join(os.getcwd(),"data","technology","technology.txt"))
+		self.import_core(str(data_path("technology","technology.txt")))
 
 		self.link_crossovers()
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -13,7 +13,7 @@ def test_asset_and_data_paths_are_absolute_existing_files():
     assert data_path("planets.txt").exists()
 
 
-def test_global_variables_imports_from_non_repo_cwd(tmp_path):
+def run_python_from_non_repo_cwd(tmp_path, code):
     env = os.environ.copy()
     env.update(
         {
@@ -24,12 +24,8 @@ def test_global_variables_imports_from_non_repo_cwd(tmp_path):
         }
     )
 
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "import global_variables; print(global_variables.courier_font.size('x'))",
-        ],
+    return subprocess.run(
+        [sys.executable, "-c", code],
         cwd=tmp_path,
         env=env,
         text=True,
@@ -38,5 +34,36 @@ def test_global_variables_imports_from_non_repo_cwd(tmp_path):
         check=False,
     )
 
+
+def test_global_variables_imports_from_non_repo_cwd(tmp_path):
+    result = run_python_from_non_repo_cwd(
+        tmp_path,
+        "import global_variables; print(global_variables.courier_font.size('x'))",
+    )
+
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip()
+
+
+def test_technology_backbone_tree_loads_from_non_repo_cwd(tmp_path):
+    result = run_python_from_non_repo_cwd(
+        tmp_path,
+        "from technology import Backbone_Tree; tree = Backbone_Tree(); print(len(tree.subject_list))",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert int(result.stdout.strip()) > 0
+
+
+def test_solar_system_initializes_from_non_repo_cwd(tmp_path):
+    result = run_python_from_non_repo_cwd(
+        tmp_path,
+        "import global_variables; from solarsystem import solarsystem; "
+        "system = solarsystem(global_variables.start_date); "
+        "print(len(system.planets), len(system.trade_resources))",
+    )
+
+    assert result.returncode == 0, result.stderr
+    planet_count, resource_count = [int(value) for value in result.stdout.split()[-2:]]
+    assert planet_count > 0
+    assert resource_count > 0

--- a/tests/test_savegame.py
+++ b/tests/test_savegame.py
@@ -48,8 +48,14 @@ def test_savegame_path_uses_validated_name_inside_save_dir(tmp_path):
 def test_list_savegames_excludes_empty_temp_invalid_and_directories(tmp_path):
     save_dir = tmp_path / "savegames"
     save_dir.mkdir()
-    for name in ["campaign-1", "zulu", "emptyfile", "autosave.tmp", "   "]:
+    for name in ["campaign-1", "zulu", "emptyfile", "autosave.tmp"]:
         (save_dir / name).write_bytes(b"placeholder")
+    try:
+        (save_dir / "   ").write_bytes(b"placeholder")
+    except OSError:
+        # Windows forbids names that are only spaces; other platforms can still
+        # exercise the list filter against this invalid directory entry.
+        pass
     (save_dir / "nested").mkdir()
 
     assert list_savegames(save_dir) == ["campaign-1", "zulu"]

--- a/tests/test_savegame.py
+++ b/tests/test_savegame.py
@@ -1,0 +1,79 @@
+import os
+import pickle
+
+import pytest
+
+from savegame import (
+    PAYLOAD_TYPE,
+    SAVE_FORMAT,
+    SAVE_VERSION,
+    SaveNameError,
+    list_savegames,
+    load_named_payload,
+    make_save_wrapper,
+    savegame_path,
+    validate_save_name,
+)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "   ",
+        os.path.abspath("slot1"),
+        "../slot1",
+        "slot1/backup",
+        r"slot1\\backup",
+        ".",
+        "..",
+        "emptyfile",
+        "autosave.tmp",
+        "AUTOSAVE.TMP",
+    ],
+)
+def test_validate_save_name_rejects_unsafe_names(name):
+    with pytest.raises(SaveNameError):
+        validate_save_name(name)
+
+
+def test_savegame_path_uses_validated_name_inside_save_dir(tmp_path):
+    save_dir = tmp_path / "savegames"
+
+    path = savegame_path(save_dir, " campaign-1 ")
+
+    assert path == os.path.join(os.fspath(save_dir), "campaign-1")
+
+
+def test_list_savegames_excludes_empty_temp_invalid_and_directories(tmp_path):
+    save_dir = tmp_path / "savegames"
+    save_dir.mkdir()
+    for name in ["campaign-1", "zulu", "emptyfile", "autosave.tmp", "   "]:
+        (save_dir / name).write_bytes(b"placeholder")
+    (save_dir / "nested").mkdir()
+
+    assert list_savegames(save_dir) == ["campaign-1", "zulu"]
+
+
+def test_new_save_wrapper_has_versioned_metadata():
+    payload = object()
+
+    wrapper = make_save_wrapper(payload, created_at="2026-06-11T12:00:00+00:00")
+
+    assert wrapper == {
+        "format": SAVE_FORMAT,
+        "version": SAVE_VERSION,
+        "created_at": "2026-06-11T12:00:00+00:00",
+        "payload_type": PAYLOAD_TYPE,
+        "payload": payload,
+    }
+
+
+def test_invalid_load_names_are_rejected_before_pickle_load(tmp_path, monkeypatch):
+    def fail_if_called(file_obj):
+        raise AssertionError("pickle.load should not run for invalid save names")
+
+    monkeypatch.setattr(pickle, "load", fail_if_called)
+
+    with pytest.raises(SaveNameError):
+        load_named_payload(tmp_path, "../campaign-1")

--- a/tests/test_simulation_foundation.py
+++ b/tests/test_simulation_foundation.py
@@ -1,0 +1,160 @@
+import random
+from types import SimpleNamespace
+
+import pytest
+
+import company
+import global_variables
+from market_decisions import market_decisions
+from solarsystem import solarsystem
+
+
+SNAPSHOT_SEED = 20260611
+
+
+def _initialized_solar_system(seed=SNAPSHOT_SEED):
+    random.seed(seed)
+    return solarsystem(global_variables.start_date, de_novo_initialization=True)
+
+
+def test_full_initialization_snapshot_is_deterministic_for_fixed_seed():
+    sol = _initialized_solar_system()
+
+    total_bases = sum(len(planet.bases) for planet in sol.planets.values())
+    total_firms = sum(len(owner.owned_firms) for owner in sol.companies.values())
+    total_trade_routes = (
+        sum(len(base.trade_routes) for planet in sol.planets.values() for base in planet.bases.values())
+        // 2
+    )
+    base_counts_by_planet = {
+        planet_name: len(planet.bases)
+        for planet_name, planet in sol.planets.items()
+        if planet.bases
+    }
+
+    assert len(sol.planets) == 193
+    assert total_bases == 255
+    assert len(sol.companies) == 500
+    assert total_firms == 7755
+    assert total_trade_routes == 808
+    assert base_counts_by_planet == {"earth": 255}
+    assert len(sol.trade_resources) == 19
+    assert len(sol.mineral_resources) == 5
+    assert len(sol.technology_tree.vertex_dict) == 149
+
+
+def test_new_solar_system_starts_with_zeroed_telemetry_keys():
+    sol = _initialized_solar_system()
+
+    assert sol.telemetry == {
+        "stockouts": 0,
+        "zero_stock_bases": 0,
+        "transactions": 0,
+        "firm_starts": 0,
+        "firm_closes": 0,
+        "bankruptcies": 0,
+    }
+
+
+def test_telemetry_counts_post_initialization_firm_starts():
+    sol = _initialized_solar_system()
+    owner = next(iter(sol.companies.values()))
+    location = next(iter(owner.home_cities.values()))
+
+    owner.change_firm_size(location, 1, "research", name="telemetry research start")
+
+    assert sol.telemetry["firm_starts"] == 1
+
+
+def test_telemetry_counts_market_transactions():
+    sol = _initialized_solar_system()
+    location = next(base for planet in sol.planets.values() for base in planet.bases.values())
+    seller_owner, buyer_owner = list(sol.companies.values())[:2]
+    seller = company.firm(
+        sol,
+        location,
+        {"input": {}, "output": {}, "timeframe": 30, "byproducts": {}},
+        seller_owner,
+        "telemetry seller",
+        "common knowledge",
+    )
+    buyer = company.firm(
+        sol,
+        location,
+        {"input": {}, "output": {}, "timeframe": 30, "byproducts": {}},
+        buyer_owner,
+        "telemetry buyer",
+        "common knowledge",
+    )
+    seller.stock_dict["food"] = 3
+    buyer_owner.capital = 1000
+    location.market["buy_offers"]["food"] = [
+        {
+            "resource": "food",
+            "price": 5.0,
+            "quantity": 3,
+            "buyer": buyer,
+            "date": sol.current_date,
+            "name": buyer.name,
+        }
+    ]
+
+    seller.make_market_bid(
+        location.market,
+        {
+            "resource": "food",
+            "price": 4.0,
+            "quantity": 3,
+            "seller": seller,
+            "date": sol.current_date,
+            "name": seller.name,
+        },
+    )
+
+    assert sol.telemetry["transactions"] == 1
+
+
+@pytest.mark.xfail(strict=True, reason="Known bug: intercity trade profit margin uses sellprice - buyprice instead of buyprice - sellprice")
+def test_intercity_trade_starts_merchant_when_destination_price_exceeds_source_price():
+    sol = _initialized_solar_system()
+    owner = next(iter(sol.companies.values()))
+    seller_base = next(base for planet in sol.planets.values() for base in planet.bases.values() if base.trade_routes)
+    buyer_base = next(iter(seller_base.trade_routes.values()))["endpoint_links"][0]
+    if buyer_base is seller_base:
+        buyer_base = next(iter(seller_base.trade_routes.values()))["endpoint_links"][1]
+
+    owner.home_cities = {seller_base.name: seller_base, buyer_base.name: buyer_base}
+    owner.company_database["tendency_to_start_trade_routes"] = 100
+    seller_base.market["sell_offers"]["food"] = [{"resource": "food", "price": 10.0, "quantity": 100}]
+    buyer_base.market["buy_offers"]["food"] = [{"resource": "food", "price": 100.0, "quantity": 100}]
+    seller_base.market["sell_offers"]["ground transport"] = [{"resource": "ground transport", "price": 0.0, "quantity": 100}]
+    buyer_base.market["sell_offers"]["ground transport"] = [{"resource": "ground transport", "price": 0.0, "quantity": 100}]
+
+    merchants_before = [firm for firm in owner.owned_firms.values() if isinstance(firm, company.merchant)]
+    global_variables.market_decisions.evaluate_intercity_trade_market_01(owner)
+    merchants_after = [firm for firm in owner.owned_firms.values() if isinstance(firm, company.merchant)]
+
+    assert len(merchants_after) == len(merchants_before) + 1
+
+
+@pytest.mark.xfail(strict=True, reason="Known bug: desired_research percentage is compared directly to a 0..1 research ratio")
+def test_research_firms_do_not_start_when_current_ratio_already_exceeds_desired_percent():
+    decisions = market_decisions()
+    subject = company.company.__new__(company.company)
+    research_firm = company.research.__new__(company.research)
+    research_firm.size = 50
+    ordinary_firm = SimpleNamespace(size=50)
+    started = []
+
+    subject.owned_firms = {"research": research_firm, "ordinary": ordinary_firm}
+    subject.company_database = {"desired_research": 40}
+    subject.home_cities = {"test city": object()}
+
+    def record_start(location, size, technology_name, name=None):
+        started.append((location, size, technology_name, name))
+
+    subject.change_firm_size = record_start
+
+    decisions.start_research_firms_01(subject)
+
+    assert started == []

--- a/tests/test_simulation_foundation.py
+++ b/tests/test_simulation_foundation.py
@@ -17,30 +17,64 @@ def _initialized_solar_system(seed=SNAPSHOT_SEED):
     return solarsystem(global_variables.start_date, de_novo_initialization=True)
 
 
-def test_full_initialization_snapshot_is_deterministic_for_fixed_seed():
-    sol = _initialized_solar_system()
+def _initialization_signature(sol):
+    """Return stable aggregates that should match for the same random seed."""
+    base_counts_by_planet = tuple(
+        sorted(
+            (planet_name, len(planet.bases))
+            for planet_name, planet in sol.planets.items()
+            if planet.bases
+        )
+    )
+    trade_route_counts_by_planet = tuple(
+        sorted(
+            (
+                planet_name,
+                sum(len(base.trade_routes) for base in planet.bases.values()),
+            )
+            for planet_name, planet in sol.planets.items()
+            if planet.bases
+        )
+    )
+    firm_counts_by_company = tuple(
+        sorted((company_name, len(owner.owned_firms)) for company_name, owner in sol.companies.items())
+    )
+    return {
+        "planets": tuple(sorted(sol.planets.keys())),
+        "base_counts_by_planet": base_counts_by_planet,
+        "trade_route_counts_by_planet": trade_route_counts_by_planet,
+        "company_count": len(sol.companies),
+        "firm_counts_by_company": firm_counts_by_company,
+        "trade_resources": tuple(sorted(sol.trade_resources.keys())),
+        "mineral_resources": tuple(sorted(sol.mineral_resources)),
+        "technology_subjects": tuple(sorted(sol.technology_tree.vertex_dict.keys())),
+    }
 
+
+def test_full_initialization_is_deterministic_for_fixed_seed():
+    first = _initialized_solar_system()
+    second = _initialized_solar_system()
+
+    assert _initialization_signature(first) == _initialization_signature(second)
+
+
+def test_full_initialization_builds_core_economy_invariants():
+    sol = _initialized_solar_system()
     total_bases = sum(len(planet.bases) for planet in sol.planets.values())
     total_firms = sum(len(owner.owned_firms) for owner in sol.companies.values())
     total_trade_routes = (
         sum(len(base.trade_routes) for planet in sol.planets.values() for base in planet.bases.values())
         // 2
     )
-    base_counts_by_planet = {
-        planet_name: len(planet.bases)
-        for planet_name, planet in sol.planets.items()
-        if planet.bases
-    }
 
-    assert len(sol.planets) == 193
-    assert total_bases == 255
-    assert len(sol.companies) == 500
-    assert total_firms == 7755
-    assert total_trade_routes == 808
-    assert base_counts_by_planet == {"earth": 255}
-    assert len(sol.trade_resources) == 19
-    assert len(sol.mineral_resources) == 5
-    assert len(sol.technology_tree.vertex_dict) == 149
+    assert {"sun", "earth", "moon", "mars"}.issubset(sol.planets)
+    assert total_bases > 0
+    assert total_trade_routes > 0
+    assert len(sol.companies) > 0
+    assert total_firms >= len(sol.companies)
+    assert {"food", "housing", "consumer goods"}.issubset(sol.trade_resources)
+    assert set(sol.mineral_resources).issubset(sol.trade_resources)
+    assert len(sol.technology_tree.vertex_dict) > 0
 
 
 def test_new_solar_system_starts_with_zeroed_telemetry_keys():

--- a/tests/test_solarsystem.py
+++ b/tests/test_solarsystem.py
@@ -1,11 +1,13 @@
 import pytest
 import os
 import datetime
+import pickle
 from PIL import Image
 from planet import planet
 from company import company
 from solarsystem import solarsystem
 import global_variables
+from savegame import PAYLOAD_TYPE, SAVE_FORMAT, SAVE_VERSION, SaveFormatError
 
 
 def test_solar_system_initialization():
@@ -190,5 +192,110 @@ def test_save_restores_loaded_planet_images_when_pickle_fails(tmpdir):
     assert isinstance(earth.topo_image, Image.Image)
     assert isinstance(earth.resource_maps["iron"], Image.Image)
     assert not os.path.exists(save_file_path + ".tmp")
+
+
+def test_new_solar_system_saves_use_versioned_wrapper(tmpdir):
+    save_file_path = os.path.join(tmpdir.mkdir("save_files"), "wrapped.pkl")
+    old_solar_system = solarsystem(start_date=global_variables.start_date)
+    old_solar_system.initialize_planets()
+
+    old_solar_system.save_solar_system(save_file_path)
+
+    with open(save_file_path, "rb") as save_file:
+        saved_object = pickle.load(save_file)
+    assert saved_object["format"] == SAVE_FORMAT
+    assert saved_object["version"] == SAVE_VERSION
+    assert saved_object["payload_type"] == PAYLOAD_TYPE
+    assert isinstance(saved_object["created_at"], str)
+    assert isinstance(saved_object["payload"], solarsystem)
+
+
+def test_versioned_wrapper_loads_solar_system(tmpdir):
+    save_file_path = os.path.join(tmpdir.mkdir("save_files"), "wrapped.pkl")
+    old_solar_system = solarsystem(start_date=global_variables.start_date)
+    old_solar_system.initialize_planets()
+    old_solar_system.current_date = global_variables.start_date + datetime.timedelta(days=42)
+    old_solar_system.save_solar_system(save_file_path)
+
+    new_solar_system = solarsystem(start_date=global_variables.start_date)
+    new_solar_system.load_solar_system(save_file_path)
+
+    assert new_solar_system.current_date == old_solar_system.current_date
+    assert new_solar_system.planets["earth"].solar_system_object_link is new_solar_system
+
+
+def test_unsupported_wrapper_version_fails_without_mutating_current_system(tmpdir):
+    save_file_path = os.path.join(tmpdir.mkdir("save_files"), "unsupported.pkl")
+    payload = solarsystem(start_date=global_variables.start_date)
+    payload.initialize_planets()
+    with open(save_file_path, "wb") as save_file:
+        pickle.dump(
+            {
+                "format": SAVE_FORMAT,
+                "version": SAVE_VERSION + 1,
+                "created_at": "2026-06-11T12:00:00+00:00",
+                "payload_type": PAYLOAD_TYPE,
+                "payload": payload,
+            },
+            save_file,
+        )
+
+    current_system = solarsystem(start_date=global_variables.start_date)
+    current_system.initialize_planets()
+    sentinel = object()
+    current_system.mutation_sentinel_for_test = sentinel
+
+    with pytest.raises(SaveFormatError, match="Unsupported savegame version"):
+        current_system.load_solar_system(save_file_path)
+
+    assert current_system.mutation_sentinel_for_test is sentinel
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    [
+        (b"", "empty"),
+        (b"not a pickle", "could not be unpickled"),
+    ],
+)
+def test_corrupt_or_empty_save_fails_without_mutating_current_system(tmpdir, contents, message):
+    save_file_path = os.path.join(tmpdir.mkdir("save_files"), "bad.pkl")
+    with open(save_file_path, "wb") as save_file:
+        save_file.write(contents)
+
+    current_system = solarsystem(start_date=global_variables.start_date)
+    current_system.initialize_planets()
+    sentinel = object()
+    current_system.mutation_sentinel_for_test = sentinel
+
+    with pytest.raises(SaveFormatError, match=message):
+        current_system.load_solar_system(save_file_path)
+
+    assert current_system.mutation_sentinel_for_test is sentinel
+
+
+def test_invalid_payload_fails_without_mutating_current_system(tmpdir):
+    save_file_path = os.path.join(tmpdir.mkdir("save_files"), "invalid.pkl")
+    with open(save_file_path, "wb") as save_file:
+        pickle.dump(
+            {
+                "format": SAVE_FORMAT,
+                "version": SAVE_VERSION,
+                "created_at": "2026-06-11T12:00:00+00:00",
+                "payload_type": "wrong-payload",
+                "payload": object(),
+            },
+            save_file,
+        )
+
+    current_system = solarsystem(start_date=global_variables.start_date)
+    current_system.initialize_planets()
+    sentinel = object()
+    current_system.mutation_sentinel_for_test = sentinel
+
+    with pytest.raises(SaveFormatError, match="Unsupported savegame payload type"):
+        current_system.load_solar_system(save_file_path)
+
+    assert current_system.mutation_sentinel_for_test is sentinel
 
 


### PR DESCRIPTION
## Summary
- Adds a central savegame wrapper/validation module while preserving legacy raw-pickle payload loads.
- Hardens save/load paths and invalid load-menu filtering without broad GUI rewrites.
- Adds repository-relative path metadata/dependencies, a small telemetry skeleton with low-risk counters, and simulation foundation tests.
- Documents known intercity trade profit-sign behavior with an xfail intended-behavior regression instead of fixing it in this wave.

## Tests run
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 .venv/bin/python -m pytest -q` — passed, output: `.........................................................xx............. [100%]`
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 .venv/bin/python -m compileall -q -x '(.git|__pycache__|.venv|venv)' .` — passed with exit code 0 and no output

## Explicitly postponed / out of scope
- No broad `gui.py` decomposition or widget rewrites.
- No browser/web/frontend/Pygame-in-browser/HTML work.
- No sections 6/7 gameplay expansion: no new resource chains, orbital redesign, route graph/pathfinding, or space-settlement AI.
- No production fix for the intercity trade profit sign in this wave.

## Notes
- `pyproject.toml` adds metadata/dependencies only; no console script or forced entry point is added.
- Historical roadmap docs may retain Ocempgui mentions for context; active code/comment remnants were removed.
