### PR TITLE
Fix simulation clock advancement

### DIFF
--- a/SimThread.py
+++ b/SimThread.py
@@ -12,16 +12,24 @@ class SimThread(threading.Thread):
         self.sol=sol
         self._stopEvent=threading.Event()
         self.daemon = True
-    def run(self):
+
+    def run_one_step(self):
         sol=self.sol
+#       print "SimThread starting another month"
+        sol.current_date = datetime.timedelta(30)+sol.current_date
+        sol.evaluate_each_game_step()
+        for company_instance in list(sol.companies.values()):
+            company_instance.evaluate_self()
+
+    def sleep_between_steps(self):
+        delay_milliseconds = getattr(self.sol, "step_delay_time", 100)
+        time.sleep(max(0, delay_milliseconds) / 1000.0)
+
+    def run(self):
         try:
             while(not self._stopEvent.is_set()):
-#            print "SimThread starting another month"
-                sol.current_date = datetime.timedelta(30)+sol.current_date
-                sol.evaluate_each_game_step()
-                for company_instance in list(sol.companies.values()):
-                    company_instance.evaluate_self()
-                time.sleep(1)
+                self.run_one_step()
+                self.sleep_between_steps()
         except Exception:
             logger.exception("Unhandled exception in simulation thread")
             raise

--- a/company.py
+++ b/company.py
@@ -1286,12 +1286,17 @@ class firm():
 
 					self.stock_dict[output_resource] = self.input_output_dict["output"][output_resource] * number_of_rounds + self.stock_dict[output_resource]
 
-				#adding byproducts to the atmosphere
+				#adding atmospheric byproducts to the atmosphere. Some byproducts, such as
+				#radioactive waste, are non-atmospheric effects until the game models them
+				#explicitly; they must not crash the simulation thread.
 				for byproduct in self.input_output_dict["byproducts"]:
-					self.location.home_planet.change_gas_in_atmosphere(byproduct,self.input_output_dict["byproducts"][byproduct] * number_of_rounds)
-					if self.owner == self.solar_system_object_link.current_player:
-						print_dict = {"text":"Because of " + self.name + " " + byproduct + " changed with " + str(self.input_output_dict["byproducts"][byproduct] * number_of_rounds) + " units on " + str(self.location.home_planet.name),"type":"climate"}
-						self.solar_system_object_link.messages.append(print_dict)
+					byproduct_amount = self.input_output_dict["byproducts"][byproduct] * number_of_rounds
+					home_planet = self.location.home_planet
+					if str("athmospheric_" + byproduct) in list(getattr(home_planet, "planet_data", {}).keys()):
+						home_planet.change_gas_in_atmosphere(byproduct, byproduct_amount)
+						if self.owner == self.solar_system_object_link.current_player:
+							print_dict = {"text":"Because of " + self.name + " " + byproduct + " changed with " + str(byproduct_amount) + " units on " + str(home_planet.name),"type":"climate"}
+							self.solar_system_object_link.messages.append(print_dict)
 
 				for resource in self.input_output_dict["output"]:
 					if resource in self.solar_system_object_link.mineral_resources:

--- a/tests/test_company_byproducts.py
+++ b/tests/test_company_byproducts.py
@@ -1,0 +1,68 @@
+import datetime
+
+import company
+
+
+class _FakeSolarSystem:
+    def __init__(self):
+        self.start_date = datetime.date(2026, 1, 1)
+        self.current_date = self.start_date
+        self.trade_resources = {}
+        self.mineral_resources = []
+        self.message_printing = {"debugging": False}
+        self.messages = []
+        self.current_player = None
+
+
+class _FakeLocation:
+    def __init__(self, home_planet):
+        self.home_planet = home_planet
+        self.mining_performed = {}
+
+
+class _FakePlanet:
+    name = "test planet"
+
+    def __init__(self, atmospheric_keys=()):
+        self.planet_data = {key: 0 for key in atmospheric_keys}
+        self.gas_changes = []
+
+    def change_gas_in_atmosphere(self, gas, ton):
+        if f"athmospheric_{gas}" not in self.planet_data:
+            raise AssertionError(f"non-atmospheric byproduct should not be treated as gas: {gas}")
+        self.gas_changes.append((gas, ton))
+
+
+def _production_firm(byproducts, planet):
+    sol = _FakeSolarSystem()
+    firm = company.firm.__new__(company.firm)
+    firm.name = "test producer"
+    firm.owner = object()
+    firm.solar_system_object_link = sol
+    firm.location = _FakeLocation(planet)
+    firm.last_consumption_date = sol.start_date
+    firm.stock_dict = {}
+    firm.input_output_dict = {
+        "input": {},
+        "output": {},
+        "timeframe": 30,
+        "byproducts": byproducts,
+    }
+    return firm, sol
+
+
+def test_non_atmospheric_byproduct_does_not_crash_production():
+    firm, sol = _production_firm({"radioactive waste": 10}, _FakePlanet())
+
+    firm.execute_stock_change(sol.start_date + datetime.timedelta(days=60))
+
+    assert firm.last_consumption_date == sol.start_date + datetime.timedelta(days=60)
+
+
+def test_atmospheric_byproduct_still_changes_planet_atmosphere():
+    planet = _FakePlanet(["athmospheric_carbondioxide"])
+    firm, sol = _production_firm({"carbondioxide": 10}, planet)
+
+    firm.execute_stock_change(sol.start_date + datetime.timedelta(days=60))
+
+    assert planet.gas_changes == [("carbondioxide", 20)]

--- a/tests/test_simthread.py
+++ b/tests/test_simthread.py
@@ -15,6 +15,49 @@ class ExplodingSolarSystem:
         raise RuntimeError("sim boom")
 
 
+class _FakeCompany:
+    def __init__(self):
+        self.evaluated = 0
+
+    def evaluate_self(self):
+        self.evaluated += 1
+
+
+class _SteppingSolarSystem:
+    def __init__(self):
+        self.current_date = datetime.date(2026, 1, 1)
+        self.companies = {"company": _FakeCompany()}
+        self.step_delay_time = 250
+        self.evaluated = 0
+
+    def evaluate_each_game_step(self):
+        self.evaluated += 1
+
+
+def test_simthread_run_one_step_advances_date_and_evaluates_world_and_companies():
+    sol = _SteppingSolarSystem()
+    thread = SimThread(sol)
+
+    thread.run_one_step()
+
+    assert sol.current_date == datetime.date(2026, 1, 31)
+    assert sol.evaluated == 1
+    assert sol.companies["company"].evaluated == 1
+
+
+def test_simthread_sleep_between_steps_uses_sol_step_delay_time_milliseconds(monkeypatch):
+    sol = _SteppingSolarSystem()
+    sol.step_delay_time = 250
+    thread = SimThread(sol)
+    sleep_calls = []
+
+    monkeypatch.setattr("SimThread.time.sleep", sleep_calls.append)
+
+    thread.sleep_between_steps()
+
+    assert sleep_calls == [0.25]
+
+
 def test_simthread_logs_unhandled_exception(caplog):
     thread = SimThread(ExplodingSolarSystem())
 


### PR DESCRIPTION
## Summary
- Prevent non-atmospheric byproducts such as radioactive waste from being sent through atmospheric gas handling and killing the simulation thread.
- Make SimThread use sol.step_delay_time in milliseconds, so the Game speed menu actually changes simulation speed.
- Add regression coverage for production byproducts and SimThread stepping/sleep behavior.

## Verification
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 .venv/bin/python -m pytest tests/test_company_byproducts.py tests/test_simthread.py -q
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 .venv/bin/python -m pytest -q
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 .venv/bin/python -m compileall -q -x '(.git|__pycache__|.venv|venv)' .
- Headless local simulation smoke: new game player setup advanced 270 days in 1.25s with thread still alive and no unhandled simulation-thread exception.