### PR TITLE
feat: improve bidding slider scaling

### DIFF
--- a/bidding_slider_scaling.py
+++ b/bidding_slider_scaling.py
@@ -1,0 +1,228 @@
+"""Pure slider scaling helpers for bidding and firm-size UI controls.
+
+The pygame scrollbars expose integer positions. These helpers keep the
+nonlinear UX mapping outside the GUI so it can be tested without opening a
+window or relying on pygame state.
+"""
+
+import math
+
+
+SLIDER_MIN = 0
+SLIDER_MAX = 1000
+SLIDER_LOW_ANCHOR = 333
+SLIDER_HIGH_ANCHOR = 667
+EDGE_EXPONENT = 2.5
+FIRM_SIZE_CAPITAL_DIVISOR = 10_000
+FIRM_SIZE_MIN_MAX = 50
+
+
+def _clamp(value, lower, upper):
+    return max(lower, min(upper, value))
+
+
+def _valid_positive(value):
+    try:
+        return value is not None and float(value) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _linear_from_slider(position, maximum):
+    maximum = max(float(maximum or 0), 0.0)
+    position = _clamp(float(position), SLIDER_MIN, SLIDER_MAX)
+    return position / float(SLIDER_MAX) * maximum
+
+
+def _linear_to_slider(value, maximum):
+    maximum = max(float(maximum or 0), 0.0)
+    if maximum <= 0:
+        return SLIDER_MIN
+    return int(round(_clamp(float(value), 0.0, maximum) / maximum * SLIDER_MAX))
+
+
+def _low_edge_value(position, anchor_value):
+    """0..LOW_ANCHOR -> 0..anchor, with finer changes near the anchor."""
+    position = _clamp(float(position), SLIDER_MIN, SLIDER_LOW_ANCHOR)
+    anchor_value = max(float(anchor_value), 0.0)
+    if anchor_value <= 0:
+        return 0.0
+    u = position / float(SLIDER_LOW_ANCHOR)
+    return anchor_value * (1.0 - math.pow(1.0 - u, EDGE_EXPONENT))
+
+
+def _low_edge_position(value, anchor_value):
+    anchor_value = max(float(anchor_value), 0.0)
+    if anchor_value <= 0:
+        return SLIDER_MIN
+    ratio = _clamp(float(value), 0.0, anchor_value) / anchor_value
+    return SLIDER_LOW_ANCHOR * (1.0 - math.pow(1.0 - ratio, 1.0 / EDGE_EXPONENT))
+
+
+def _high_edge_value(position, anchor_value, maximum_value):
+    """HIGH_ANCHOR..MAX -> anchor..maximum, with finer changes near anchor."""
+    anchor_value = max(float(anchor_value), 0.0)
+    maximum_value = max(float(maximum_value), anchor_value)
+    if maximum_value <= anchor_value:
+        return anchor_value
+    position = _clamp(float(position), SLIDER_HIGH_ANCHOR, SLIDER_MAX)
+    u = (position - SLIDER_HIGH_ANCHOR) / float(SLIDER_MAX - SLIDER_HIGH_ANCHOR)
+    return anchor_value + (maximum_value - anchor_value) * math.pow(u, EDGE_EXPONENT)
+
+
+def _high_edge_position(value, anchor_value, maximum_value):
+    anchor_value = max(float(anchor_value), 0.0)
+    maximum_value = max(float(maximum_value), anchor_value)
+    if maximum_value <= anchor_value:
+        return SLIDER_HIGH_ANCHOR
+    ratio = (float(value) - anchor_value) / (maximum_value - anchor_value)
+    ratio = _clamp(ratio, 0.0, 1.0)
+    return SLIDER_HIGH_ANCHOR + (SLIDER_MAX - SLIDER_HIGH_ANCHOR) * math.pow(ratio, 1.0 / EDGE_EXPONENT)
+
+
+def firm_size_slider_max(capital, population_limited_max=None, minimum=FIRM_SIZE_MIN_MAX):
+    """Return a conservative max firm size for the creation slider.
+
+    Firm creation itself does not currently debit capital, so this is a UI
+    range heuristic rather than a hard affordability check. The default
+    10,000,000 starting capital maps to roughly the old large range of 1,000;
+    larger companies get a larger range; very small companies still get a
+    usable range; and an existing population-derived max is respected when it
+    is larger.
+    """
+    try:
+        capital_based = int(float(capital) / FIRM_SIZE_CAPITAL_DIVISOR)
+    except (TypeError, ValueError):
+        capital_based = 0
+
+    candidates = [int(minimum), capital_based]
+    if population_limited_max is not None:
+        try:
+            candidates.append(int(population_limited_max))
+        except (TypeError, ValueError):
+            pass
+    return max(1, max(candidates))
+
+
+def firm_size_from_slider(position, max_size, min_size=1):
+    """Map top-to-bottom vertical slider position to logarithmic firm size."""
+    max_size = max(int(max_size), int(min_size))
+    min_size = max(1, int(min_size))
+    position = _clamp(float(position), SLIDER_MIN, SLIDER_MAX)
+    if max_size <= min_size:
+        return min_size
+    ratio = position / float(SLIDER_MAX)
+    value = min_size * math.pow(float(max_size) / float(min_size), ratio)
+    return int(_clamp(round(value), min_size, max_size))
+
+
+def firm_size_to_slider(size, max_size, min_size=1):
+    max_size = max(int(max_size), int(min_size))
+    min_size = max(1, int(min_size))
+    size = _clamp(float(size), min_size, max_size)
+    if max_size <= min_size:
+        return SLIDER_MIN
+    ratio = math.log(size / float(min_size)) / math.log(float(max_size) / float(min_size))
+    return int(round(_clamp(ratio, 0.0, 1.0) * SLIDER_MAX))
+
+
+def _usable_price_anchors(highest_buy_offer, lowest_sell_offer):
+    if not (_valid_positive(highest_buy_offer) and _valid_positive(lowest_sell_offer)):
+        return None
+    low_anchor_value = float(highest_buy_offer)
+    high_anchor_value = float(lowest_sell_offer)
+    if high_anchor_value <= low_anchor_value:
+        # Crossed/odd markets violate the nominal labels. Preserve a monotonic
+        # usable control by widening the 2/3 anchor just above the 1/3 value.
+        high_anchor_value = low_anchor_value + max(1.0, low_anchor_value * 0.05)
+    return low_anchor_value, high_anchor_value
+
+
+def market_price_from_slider(position, highest_buy_offer=None, lowest_sell_offer=None, fallback_max=0):
+    anchors = _usable_price_anchors(highest_buy_offer, lowest_sell_offer)
+    if anchors is None:
+        return int(round(_linear_from_slider(position, fallback_max)))
+
+    low_anchor_value, high_anchor_value = anchors
+    position = _clamp(float(position), SLIDER_MIN, SLIDER_MAX)
+    if position <= SLIDER_LOW_ANCHOR:
+        value = _low_edge_value(position, low_anchor_value)
+    elif position <= SLIDER_HIGH_ANCHOR:
+        ratio = (position - SLIDER_LOW_ANCHOR) / float(SLIDER_HIGH_ANCHOR - SLIDER_LOW_ANCHOR)
+        value = low_anchor_value + (high_anchor_value - low_anchor_value) * ratio
+    else:
+        upper = max(high_anchor_value * 100.0, high_anchor_value + float(fallback_max or 0) * 10.0, high_anchor_value + 1.0)
+        value = _high_edge_value(position, high_anchor_value, upper)
+    return int(round(max(0.0, value)))
+
+
+def market_price_to_slider(price, highest_buy_offer=None, lowest_sell_offer=None, fallback_max=0):
+    anchors = _usable_price_anchors(highest_buy_offer, lowest_sell_offer)
+    if anchors is None:
+        return _linear_to_slider(price, fallback_max)
+
+    low_anchor_value, high_anchor_value = anchors
+    price = max(float(price), 0.0)
+    if price <= low_anchor_value:
+        position = _low_edge_position(price, low_anchor_value)
+    elif price <= high_anchor_value:
+        ratio = (price - low_anchor_value) / (high_anchor_value - low_anchor_value)
+        position = SLIDER_LOW_ANCHOR + ratio * (SLIDER_HIGH_ANCHOR - SLIDER_LOW_ANCHOR)
+    else:
+        upper = max(high_anchor_value * 100.0, high_anchor_value + float(fallback_max or 0) * 10.0, high_anchor_value + 1.0)
+        position = _high_edge_position(price, high_anchor_value, upper)
+    return int(round(_clamp(position, SLIDER_MIN, SLIDER_MAX)))
+
+
+def quantity_anchor_for_direction(input_output_dict, direction, resource):
+    if not input_output_dict:
+        return None
+    if direction == "buy":
+        section = "input"
+    elif direction == "sell":
+        section = "output"
+    else:
+        return None
+    try:
+        value = input_output_dict.get(section, {}).get(resource)
+    except AttributeError:
+        return None
+    if not _valid_positive(value):
+        return None
+    return float(value)
+
+
+def quantity_from_slider(position, anchor_quantity=None, fallback_max=0):
+    if not _valid_positive(anchor_quantity):
+        return int(round(_linear_from_slider(position, fallback_max)))
+
+    anchor = float(anchor_quantity)
+    high_anchor_quantity = anchor * 10.0
+    maximum_quantity = anchor * 100.0
+    position = _clamp(float(position), SLIDER_MIN, SLIDER_MAX)
+    if position <= SLIDER_LOW_ANCHOR:
+        value = _low_edge_value(position, anchor)
+    elif position <= SLIDER_HIGH_ANCHOR:
+        ratio = (position - SLIDER_LOW_ANCHOR) / float(SLIDER_HIGH_ANCHOR - SLIDER_LOW_ANCHOR)
+        value = anchor + (high_anchor_quantity - anchor) * ratio
+    else:
+        value = _high_edge_value(position, high_anchor_quantity, maximum_quantity)
+    return int(round(max(0.0, value)))
+
+
+def quantity_to_slider(quantity, anchor_quantity=None, fallback_max=0):
+    if not _valid_positive(anchor_quantity):
+        return _linear_to_slider(quantity, fallback_max)
+
+    anchor = float(anchor_quantity)
+    high_anchor_quantity = anchor * 10.0
+    maximum_quantity = anchor * 100.0
+    quantity = max(float(quantity), 0.0)
+    if quantity <= anchor:
+        position = _low_edge_position(quantity, anchor)
+    elif quantity <= high_anchor_quantity:
+        ratio = (quantity - anchor) / (high_anchor_quantity - anchor)
+        position = SLIDER_LOW_ANCHOR + ratio * (SLIDER_HIGH_ANCHOR - SLIDER_LOW_ANCHOR)
+    else:
+        position = _high_edge_position(quantity, high_anchor_quantity, maximum_quantity)
+    return int(round(_clamp(position, SLIDER_MIN, SLIDER_MAX)))

--- a/gui.py
+++ b/gui.py
@@ -11,6 +11,17 @@ import primitives
 import gui_components
 import random
 import time
+from bidding_slider_scaling import (
+    SLIDER_MAX,
+    firm_size_from_slider,
+    firm_size_slider_max,
+    firm_size_to_slider,
+    market_price_from_slider,
+    market_price_to_slider,
+    quantity_anchor_for_direction,
+    quantity_from_slider,
+    quantity_to_slider,
+)
 from savegame import SaveNameError, list_savegames, savegame_path
 
 from solarsystem import solarsystem
@@ -2414,14 +2425,24 @@ class base_and_firm_market_window():
         if initial_price is not None:
             max_price = max(initial_price, max_price)
 
+        highest_buy_offer = None
+        lowest_sell_offer = None
         if len(market["buy_offers"][resource]) > 0:
-            max_price = max(market["buy_offers"][resource][0]["price"], max_price)
+            highest_buy_offer = market["buy_offers"][resource][0]["price"]
+            max_price = max(highest_buy_offer, max_price)
+        if len(market["sell_offers"][resource]) > 0:
+            lowest_sell_offer = market["sell_offers"][resource][0]["price"]
+            max_price = max(lowest_sell_offer, max_price)
 
         for transaction in market["transactions"][resource]:
             max_price = max(max_price, transaction["price"])
 
 
-        price_range = (0,int(max_price * 2))
+        price_fallback_max = int(max_price * 2)
+        price_slider_range = (0, SLIDER_MAX)
+        if initial_price is None:
+            initial_price = max_price
+        pre_selected_price_slider = market_price_to_slider(initial_price, highest_buy_offer, lowest_sell_offer, price_fallback_max)
 
 
 #        print "initial_quantity: " + str(initial_quantity)
@@ -2442,31 +2463,33 @@ class base_and_firm_market_window():
         variable_price_text = global_variables.standard_font.render(str(int(initial_price)),True,(0,0,0))
         self.action_surface.blit(variable_price_text, (price_rect[0], price_rect[1]))
 
+        price_bar_left = self.graph_rect[0] + 10
+        price_bar_width = self.graph_rect[2]-20
+        highest_buy_label = global_variables.standard_font_small.render("highest buy offer",True,(0,0,0))
+        lowest_sell_label = global_variables.standard_font_small.render("lowest sell offer",True,(0,0,0))
+        self.action_surface.blit(highest_buy_label, (price_bar_left + int(price_bar_width / 3) - int(highest_buy_label.get_width() / 2), self.graph_rect[1] + height_to_draw + 8))
+        self.action_surface.blit(lowest_sell_label, (price_bar_left + int(2 * price_bar_width / 3) - int(lowest_sell_label.get_width() / 2), self.graph_rect[1] + height_to_draw + 8))
 
         def price_execute(label, price_rect):
             pygame.draw.rect(self.action_surface,(212,212,212),price_rect)
-            variable_price_text = global_variables.standard_font.render(str(self.price_bar.position),True,(0,0,0))
+            price = market_price_from_slider(self.price_bar.position, highest_buy_offer, lowest_sell_offer, price_fallback_max)
+            variable_price_text = global_variables.standard_font.render(str(price),True,(0,0,0))
             self.action_surface.blit(variable_price_text, (price_rect[0], price_rect[1]))
             pygame.display.update(price_rect)
-
-        if price_range[0] > int(initial_price) or int(initial_price) > price_range[1]:
-            print(int(max_price))
-            print(price_range)
-            raise Exception("This has been observed before... check print outs")
 
 
         self.price_bar = gui_components.hscrollbar(self.action_surface,
                                   price_execute,
-                                  (self.graph_rect[0] + 10, self.graph_rect[1] + height_to_draw + 20),
-                                  self.graph_rect[2]-20,
-                                  price_range,
-                                  start_position = int(max_price),
+                                  (price_bar_left, self.graph_rect[1] + height_to_draw + 25),
+                                  price_bar_width,
+                                  price_slider_range,
+                                  start_position = pre_selected_price_slider,
                                   function_parameter=price_rect)
 
 
 
         #row 2 set the quantity
-        height_to_draw = height_to_draw + 60
+        height_to_draw = height_to_draw + 70
 
         fixed_quantity_text = global_variables.standard_font.render("Set the quantity:",True,(0,0,0))
         self.action_surface.blit(fixed_quantity_text, (self.graph_rect[0], self.graph_rect[1] + height_to_draw))
@@ -2474,20 +2497,29 @@ class base_and_firm_market_window():
         variable_quantity_text = global_variables.standard_font.render(str(initial_quantity),True,(0,0,0))
         self.action_surface.blit(variable_quantity_text, (quantity_rect[0], quantity_rect[1]))
 
+        def current_quantity_anchor():
+            selected_direction = direction
+            if hasattr(self, "direction_buttons"):
+                selected_direction = self.direction_buttons.selected
+            return quantity_anchor_for_direction(firm_selected.input_output_dict, selected_direction, resource)
 
 
         def quantity_execute(label, quantity_rect):
             pygame.draw.rect(self.action_surface,(212,212,212),quantity_rect)
-            variable_quantity_text = global_variables.standard_font.render(str(self.quantity_bar.position),True,(0,0,0))
+            quantity = quantity_from_slider(self.quantity_bar.position, current_quantity_anchor(), quantity_max)
+            variable_quantity_text = global_variables.standard_font.render(str(quantity),True,(0,0,0))
             self.action_surface.blit(variable_quantity_text, (quantity_rect[0], quantity_rect[1]))
             pygame.display.update(quantity_rect)
 
+        quantity_slider_range = (0, SLIDER_MAX)
+        self.manual_bid_quantity_fallback_max = quantity_max
+        pre_selected_quantity_slider = quantity_to_slider(pre_selected_quantity, current_quantity_anchor(), quantity_max)
         self.quantity_bar = gui_components.hscrollbar(self.action_surface,
                                   quantity_execute,
                                   (self.graph_rect[0] + 10, self.graph_rect[1] + height_to_draw + 20),
                                   self.graph_rect[2]-10,
-                                  quantity_range,
-                                  start_position = pre_selected_quantity,
+                                  quantity_slider_range,
+                                  start_position = pre_selected_quantity_slider,
                                   function_parameter=quantity_rect)
 
 
@@ -2503,7 +2535,8 @@ class base_and_firm_market_window():
 #            print "direction"
 #            print label
 #            print function_parameter
-            pass
+            if hasattr(self, "quantity_bar"):
+                quantity_execute(self.quantity_bar.position, quantity_rect)
 
 
         self.direction_buttons = gui_components.radiobuttons(["buy","sell"],
@@ -2541,14 +2574,35 @@ class base_and_firm_market_window():
             firm_selected = self.solar_system_object_link.firm_selected
         else:
             raise Exception("The display mode " + str(self.solar_system_object_link.display_mode) + " is not supposed to show market data")
-        price = self.price_bar.position
-        quantity = self.quantity_bar.position
-
         #determining direction
         direction = self.direction_buttons.selected
 
         #determining resource
         resource = self.resource_selected
+
+        if isinstance(firm_selected, company.merchant):
+            market_for_anchor = market
+        else:
+            market_for_anchor = firm_selected.location.market
+        highest_buy_offer = None
+        lowest_sell_offer = None
+        if len(market_for_anchor["buy_offers"][resource]) > 0:
+            highest_buy_offer = market_for_anchor["buy_offers"][resource][0]["price"]
+        if len(market_for_anchor["sell_offers"][resource]) > 0:
+            lowest_sell_offer = market_for_anchor["sell_offers"][resource][0]["price"]
+        fallback_max = 0
+        if highest_buy_offer is not None:
+            fallback_max = max(fallback_max, highest_buy_offer)
+        if lowest_sell_offer is not None:
+            fallback_max = max(fallback_max, lowest_sell_offer)
+        for transaction in market_for_anchor["transactions"][resource]:
+            fallback_max = max(fallback_max, transaction["price"])
+        fallback_max = int(fallback_max * 2)
+
+        quantity_fallback_max = max(1, getattr(self, "manual_bid_quantity_fallback_max", self.quantity_bar.range_of_values[1]))
+        quantity_anchor = quantity_anchor_for_direction(firm_selected.input_output_dict, direction, resource)
+        price = market_price_from_slider(self.price_bar.position, highest_buy_offer, lowest_sell_offer, fallback_max)
+        quantity = quantity_from_slider(self.quantity_bar.position, quantity_anchor, quantity_fallback_max)
 
         #determining unit
         unit = self.solar_system_object_link.trade_resources[resource]["unit_of_measurment"]
@@ -3053,7 +3107,8 @@ class base_build_menu():
         if self.solar_system_object_link.current_planet.current_base is None:
             raise Exception("very weird - there was no base selected")
         population = self.solar_system_object_link.current_planet.current_base.population
-        max_size = max(int(population * 0.05 / float(input_size)),1)
+        population_limited_max = max(int(population * 0.05 / float(input_size)),1)
+        max_size = firm_size_slider_max(self.solar_system_object_link.current_player.capital, population_limited_max)
 
 
         #check if the current_player already owns a company of that technology in the current base
@@ -3098,11 +3153,14 @@ class base_build_menu():
         self.action_surface.blit(text, (self.rect[0] + 90, self.rect[1] + 150))
 
 
-        fastest = global_variables.standard_font.render("Smallest",True,(0,0,0))
-        self.action_surface.blit(fastest, (self.rect[0] + 40, self.rect[1] + 40))
+        small_label = global_variables.standard_font.render("Small",True,(0,0,0))
+        self.action_surface.blit(small_label, (self.rect[0] + 40, self.rect[1] + 40))
 
-        slowest = global_variables.standard_font.render("Largest",True,(0,0,0))
-        self.action_surface.blit(slowest, (self.rect[0] + 40, self.rect[1] + self.rect[3]-  50))
+        medium_label = global_variables.standard_font.render("Medium",True,(0,0,0))
+        self.action_surface.blit(medium_label, (self.rect[0] + 40, self.rect[1] + int(self.rect[3] / 2)))
+
+        large_label = global_variables.standard_font.render("Large",True,(0,0,0))
+        self.action_surface.blit(large_label, (self.rect[0] + 40, self.rect[1] + self.rect[3]-  50))
 
 
         def execute(label, technology):
@@ -3113,7 +3171,9 @@ class base_build_menu():
             update_rect = pygame.Rect(self.rect[0] + 50, self.rect[1] + 170, self.rect[2] - 100, self.rect[3] - 250)
             pygame.draw.rect(self.action_surface, (212,212,212), update_rect)
 
-            size_info = global_variables.standard_font_small.render("size: " + str(self.slider.position),True,(0,0,0))
+            selected_size = firm_size_from_slider(self.slider.position, max_size)
+            self.selected_firm_size = selected_size
+            size_info = global_variables.standard_font_small.render("size: " + str(selected_size),True,(0,0,0))
             self.action_surface.blit(size_info, (self.rect[0] + 130, self.rect[1] + 170))
             lineno = 0
             for put in ["input","output"]:
@@ -3127,12 +3187,12 @@ class base_build_menu():
                         mining_opportunity = self.solar_system_object_link.current_planet.current_base.get_mining_opportunities(self.solar_system_object_link.current_planet, resource)
                         unmodified_output = technology["input_output_dict"]["output"][resource]
                         value = (mining_opportunity / 10) * unmodified_output
-                        value = int(value * self.slider.position)
+                        value = int(value * selected_size)
                         value_info = global_variables.standard_font_small.render(resource + ": " + str(value) + " (location modifier: " + str(round(mining_opportunity,2)) + ")",True,(0,0,0))
 
                     else:
                         value = technology["input_output_dict"][put][resource]
-                        value = value * self.slider.position
+                        value = value * selected_size
                         value_info = global_variables.standard_font_small.render(resource + ": " + str(value),True,(0,0,0))
 
 
@@ -3158,12 +3218,13 @@ class base_build_menu():
             print(firm_type)
             raise Exception("This has been observed before. See printout")
 
+        self.firm_size_slider_max = max_size
         self.slider = gui_components.vscrollbar (self.action_surface,
                                                 execute,
                                                 topleft = (self.rect[0] + 10, self.rect[1] + 30),
                                                 length_of_bar_in_pixel = self.rect[3] - 60,
-                                                range_of_values = (1,max_size),
-                                                start_position = start_value,
+                                                range_of_values = (0,SLIDER_MAX),
+                                                start_position = firm_size_to_slider(start_value, max_size),
                                                 function_parameter = technology
                                                 )
         execute(None,technology)
@@ -3241,7 +3302,7 @@ class base_build_menu():
         technology = self.selections["technology"]
         location = self.solar_system_object_link.current_planet.current_base
         owner = self.solar_system_object_link.current_player
-        size = self.slider.position
+        size = getattr(self, "selected_firm_size", firm_size_from_slider(self.slider.position, getattr(self, "firm_size_slider_max", self.slider.range_of_values[1])))
 
         owner.change_firm_size(location,size,technology["technology_name"], name)
         if isinstance(name, str) or isinstance(name, str):

--- a/tests/test_bidding_slider_scaling.py
+++ b/tests/test_bidding_slider_scaling.py
@@ -1,0 +1,108 @@
+import pytest
+
+from bidding_slider_scaling import (
+    SLIDER_HIGH_ANCHOR,
+    SLIDER_LOW_ANCHOR,
+    SLIDER_MAX,
+    firm_size_from_slider,
+    firm_size_slider_max,
+    firm_size_to_slider,
+    market_price_from_slider,
+    market_price_to_slider,
+    quantity_anchor_for_direction,
+    quantity_from_slider,
+    quantity_to_slider,
+)
+
+
+def test_firm_size_slider_uses_log_mapping_with_small_top_and_large_bottom():
+    max_size = 1000
+
+    assert firm_size_from_slider(0, max_size) == 1
+    assert firm_size_from_slider(SLIDER_MAX, max_size) == max_size
+    assert 25 <= firm_size_from_slider(SLIDER_MAX // 2, max_size) <= 45
+    assert firm_size_from_slider(10, max_size) - firm_size_from_slider(0, max_size) <= 1
+    assert firm_size_from_slider(SLIDER_MAX, max_size) - firm_size_from_slider(SLIDER_MAX - 10, max_size) > 50
+
+
+def test_firm_size_slider_max_scales_with_capital_but_has_floor_and_population_context():
+    assert firm_size_slider_max(capital=1000, population_limited_max=1) >= 50
+    assert 900 <= firm_size_slider_max(capital=10_000_000, population_limited_max=200) <= 1200
+    assert firm_size_slider_max(capital=100_000_000, population_limited_max=200) > firm_size_slider_max(
+        capital=10_000_000,
+        population_limited_max=200,
+    )
+    assert firm_size_slider_max(capital=10_000, population_limited_max=500) >= 500
+
+
+def test_firm_size_inverse_round_trips_representative_values():
+    for size in (1, 5, 25, 100, 1000):
+        slider_position = firm_size_to_slider(size, 1000)
+        assert abs(firm_size_from_slider(slider_position, 1000) - size) <= max(1, int(size * 0.03))
+
+
+def test_market_price_mapping_anchors_linear_middle_and_nonlinear_edges():
+    highest_buy = 30
+    lowest_sell = 90
+
+    assert market_price_from_slider(SLIDER_LOW_ANCHOR, highest_buy, lowest_sell, fallback_max=180) == highest_buy
+    assert market_price_from_slider(SLIDER_HIGH_ANCHOR, highest_buy, lowest_sell, fallback_max=180) == lowest_sell
+    assert market_price_from_slider((SLIDER_LOW_ANCHOR + SLIDER_HIGH_ANCHOR) // 2, highest_buy, lowest_sell, fallback_max=180) == pytest.approx(60, abs=1)
+    assert market_price_from_slider(0, highest_buy, lowest_sell, fallback_max=180) == 0
+    assert market_price_from_slider(SLIDER_MAX, highest_buy, lowest_sell, fallback_max=180) >= lowest_sell * 50
+
+    near_buy_step = market_price_from_slider(SLIDER_LOW_ANCHOR, highest_buy, lowest_sell, fallback_max=180) - market_price_from_slider(SLIDER_LOW_ANCHOR - 10, highest_buy, lowest_sell, fallback_max=180)
+    near_zero_step = market_price_from_slider(10, highest_buy, lowest_sell, fallback_max=180) - market_price_from_slider(0, highest_buy, lowest_sell, fallback_max=180)
+    assert near_zero_step > near_buy_step
+
+
+def test_market_price_mapping_falls_back_without_both_anchors_and_handles_crossed_market():
+    assert market_price_from_slider(SLIDER_MAX // 2, None, 90, fallback_max=200) == 100
+    assert market_price_from_slider(SLIDER_MAX // 2, 30, None, fallback_max=200) == 100
+
+    crossed_values = [market_price_from_slider(pos, 100, 50, fallback_max=200) for pos in range(0, SLIDER_MAX + 1, 50)]
+    assert crossed_values == sorted(crossed_values)
+    assert crossed_values[SLIDER_LOW_ANCHOR // 50] <= crossed_values[SLIDER_HIGH_ANCHOR // 50]
+
+
+def test_market_price_inverse_round_trips_representative_values():
+    highest_buy = 30
+    lowest_sell = 90
+    for price in (0, 10, 30, 60, 90, 900):
+        slider_position = market_price_to_slider(price, highest_buy, lowest_sell, fallback_max=180)
+        assert market_price_from_slider(slider_position, highest_buy, lowest_sell, fallback_max=180) == pytest.approx(price, rel=0.05, abs=2)
+
+
+def test_quantity_mapping_anchors_supply_time_units_and_nonlinear_edges():
+    assert quantity_from_slider(SLIDER_LOW_ANCHOR, 17, fallback_max=850) == 17
+    assert quantity_from_slider(SLIDER_HIGH_ANCHOR, 17, fallback_max=850) == 170
+    assert quantity_from_slider(SLIDER_LOW_ANCHOR, 123, fallback_max=6150) == 123
+    assert quantity_from_slider(SLIDER_HIGH_ANCHOR, 123, fallback_max=6150) == 1230
+    assert quantity_from_slider(0, 17, fallback_max=850) == 0
+    assert quantity_from_slider(SLIDER_MAX, 17, fallback_max=850) >= 1700
+
+    near_anchor_step = quantity_from_slider(SLIDER_LOW_ANCHOR, 17, fallback_max=850) - quantity_from_slider(SLIDER_LOW_ANCHOR - 10, 17, fallback_max=850)
+    near_zero_step = quantity_from_slider(10, 17, fallback_max=850) - quantity_from_slider(0, 17, fallback_max=850)
+    assert near_zero_step > near_anchor_step
+
+
+def test_quantity_mapping_falls_back_when_selected_resource_has_no_supply_anchor():
+    assert quantity_from_slider(SLIDER_MAX // 2, None, fallback_max=800) == 400
+
+
+def test_quantity_inverse_round_trips_representative_values():
+    for quantity in (0, 5, 17, 90, 170, 1700):
+        slider_position = quantity_to_slider(quantity, 17, fallback_max=850)
+        assert quantity_from_slider(slider_position, 17, fallback_max=850) == pytest.approx(quantity, rel=0.05, abs=2)
+
+
+def test_quantity_anchor_for_direction_uses_inputs_for_buy_and_outputs_for_sell():
+    process = {
+        "input": {"labor": 17},
+        "output": {"education": 123},
+    }
+
+    assert quantity_anchor_for_direction(process, "buy", "labor") == 17
+    assert quantity_anchor_for_direction(process, "sell", "education") == 123
+    assert quantity_anchor_for_direction(process, "buy", "education") is None
+    assert quantity_anchor_for_direction(process, "sell", "labor") is None


### PR DESCRIPTION
## Summary
- add pure nonlinear slider scaling helpers for firm size, market bid price, and quantity
- wire manual bidding sliders to anchored exponential/log behavior with requested labels
- scale new-firm size range from company capital while preserving a usable floor

## Test Plan
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/ubuntu/leo_data/highfrontier/.venv/bin/python -m pytest tests/test_bidding_slider_scaling.py -q
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/ubuntu/leo_data/highfrontier/.venv/bin/python -m pytest -q
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/ubuntu/leo_data/highfrontier/.venv/bin/python -m compileall -q -x '(.git|__pycache__|.venv|venv)' .