### PR TITLE
fix: polish market bid UI edge cases

### DIFF
--- a/bidding_slider_scaling.py
+++ b/bidding_slider_scaling.py
@@ -192,9 +192,34 @@ def quantity_anchor_for_direction(input_output_dict, direction, resource):
     return float(value)
 
 
-def quantity_from_slider(position, anchor_quantity=None, fallback_max=0):
+def quantity_cap_for_direction(direction, resource, stock_dict=None, buy_fallback_max=0):
+    """Return the hard quantity cap for a manual bid direction.
+
+    Sell orders are constrained by current stock. Buy orders use the existing
+    fallback range because they are constrained later by capital/validation.
+    """
+    if direction == "sell":
+        try:
+            return max(0, int(stock_dict.get(resource, 0)))
+        except AttributeError:
+            return 0
+    return max(0, int(buy_fallback_max or 0))
+
+
+def _cap_quantity(value, max_quantity):
+    if max_quantity is None:
+        return value
+    try:
+        cap = max(0.0, float(max_quantity))
+    except (TypeError, ValueError):
+        return value
+    return _clamp(value, 0.0, cap)
+
+
+def quantity_from_slider(position, anchor_quantity=None, fallback_max=0, max_quantity=None):
     if not _valid_positive(anchor_quantity):
-        return int(round(_linear_from_slider(position, fallback_max)))
+        value = _linear_from_slider(position, fallback_max)
+        return int(round(_cap_quantity(value, max_quantity)))
 
     anchor = float(anchor_quantity)
     high_anchor_quantity = anchor * 10.0
@@ -207,10 +232,21 @@ def quantity_from_slider(position, anchor_quantity=None, fallback_max=0):
         value = anchor + (high_anchor_quantity - anchor) * ratio
     else:
         value = _high_edge_value(position, high_anchor_quantity, maximum_quantity)
-    return int(round(max(0.0, value)))
+    return int(round(_cap_quantity(max(0.0, value), max_quantity)))
 
 
-def quantity_to_slider(quantity, anchor_quantity=None, fallback_max=0):
+def quantity_to_slider(quantity, anchor_quantity=None, fallback_max=0, max_quantity=None):
+    if max_quantity is not None:
+        try:
+            cap = max(0.0, float(max_quantity))
+            if cap <= 0:
+                return SLIDER_MIN
+            if float(quantity) >= cap:
+                return SLIDER_MAX
+            quantity = _clamp(float(quantity), 0.0, cap)
+        except (TypeError, ValueError):
+            pass
+
     if not _valid_positive(anchor_quantity):
         return _linear_to_slider(quantity, fallback_max)
 

--- a/company.py
+++ b/company.py
@@ -1281,10 +1281,17 @@ class firm():
 				for input_resource in new_stock_level:
 					self.stock_dict[input_resource] = new_stock_level[input_resource]
 				for output_resource in self.input_output_dict["output"]:
+					# Some technology outputs are non-stockpiled gameplay effects
+					# (for example terraforming). Until they have explicit effect
+					# handling, they should not appear as market products or crash
+					# production by indexing trade_resources/stock_dict.
+					if output_resource not in self.solar_system_object_link.trade_resources:
+						self.stock_dict.pop(output_resource, None)
+						continue
 					if not self.solar_system_object_link.trade_resources[output_resource]["storable"]:
 						self.stock_dict[output_resource] = 0
 
-					self.stock_dict[output_resource] = self.input_output_dict["output"][output_resource] * number_of_rounds + self.stock_dict[output_resource]
+					self.stock_dict[output_resource] = self.input_output_dict["output"][output_resource] * number_of_rounds + self.stock_dict.get(output_resource, 0)
 
 				#adding atmospheric byproducts to the atmosphere. Some byproducts, such as
 				#radioactive waste, are non-atmospheric effects until the game models them

--- a/data/economy/trade resources.txt
+++ b/data/economy/trade resources.txt
@@ -18,4 +18,3 @@ ground transport	False	False	transportation	100	ton/km	False	NA	NA	NA
 space transport	False	False	transportation	100	ton/km	False	NA	NA	NA
 oxygen	True	True	manufacturing	5	ton	False	NA	NA	NA
 nitrogen	True	True	manufacturing	5	ton	False	NA	NA	NA
-terraforming	False	False	service	100	units	False	NA	NA	NA

--- a/gui.py
+++ b/gui.py
@@ -19,6 +19,7 @@ from bidding_slider_scaling import (
     market_price_from_slider,
     market_price_to_slider,
     quantity_anchor_for_direction,
+    quantity_cap_for_direction,
     quantity_from_slider,
     quantity_to_slider,
 )
@@ -1152,7 +1153,7 @@ class trade_window():
             self.solar_system_object_link.messages.append(print_dict)
             return None
 #        else:
-#            print str(price) + " is ok within capital"
+#            print primitives.nicefy_numbers(price) + " is ok within capital"
 
 
         if self.selections["sale_object"].for_sale_deadline is not None:
@@ -1169,7 +1170,7 @@ class trade_window():
 
 
         self.selections["sale_object"].for_sale_bids[self.solar_system_object_link.current_player] = price
-        print_dict = {"text":"You have bid " + str(price) + " for " + str(self.selections["bid_on"]) + " - the auction will run till: " + str(self.selections["sale_object"].for_sale_deadline),"type":"general gameplay info"}
+        print_dict = {"text":"You have bid " + primitives.nicefy_numbers(price) + " for " + str(self.selections["bid_on"]) + " - the auction will run till: " + str(self.selections["sale_object"].for_sale_deadline),"type":"general gameplay info"}
         self.solar_system_object_link.messages.append(print_dict)
         return "clear"
 
@@ -1691,8 +1692,17 @@ class file_window():
             earth = sol.planets["earth"]
             base_names_chosen = ["stockholm","glasgow","bremen","rotterdam","stuttgart","genoa"]
             bases_chosen = {}
+            missing_bases = []
             for base_name_chosen in base_names_chosen:
-                bases_chosen[base_name_chosen] = earth.bases[base_name_chosen]
+                if base_name_chosen in earth.bases:
+                    bases_chosen[base_name_chosen] = earth.bases[base_name_chosen]
+                else:
+                    missing_bases.append(base_name_chosen)
+            if missing_bases:
+                sol.messages.append({"text":"Nuclear war scenario skipped missing bases: " + ", ".join(missing_bases),"type":"general gameplay info"})
+            if not bases_chosen:
+                sol.messages.append({"text":"Nuclear war scenario not available: no configured target bases exist in this map.","type":"general gameplay info"})
+                return
             earth.explode(56,10,bases_chosen,self.action_surface)
         else:
             return
@@ -2148,19 +2158,19 @@ class base_and_firm_market_window():
                 max_price = max(prices)
                 min_price = min(prices)
                 max_quantity = max(quantities)
-                sell = global_variables.standard_font.render("Max sell price: " + "%.5g" % max_price,True,(0,0,0))
-                buy = global_variables.standard_font.render("Min buy price: " + "%.5g" % min_price,True,(0,0,0))
+                sell = global_variables.standard_font.render("Max sell price: " + primitives.nicefy_numbers(max_price),True,(0,0,0))
+                buy = global_variables.standard_font.render("Min buy price: " + primitives.nicefy_numbers(min_price),True,(0,0,0))
                 if len(market["buy_offers"][resource]) == 0:
                     market_price = market["sell_offers"][resource][0]["price"]
-                    market_price_description = "Only sell offers. Lowest is: " + "%.5g" % market["sell_offers"][resource][0]["price"]
+                    market_price_description = "Only sell offers. Lowest is: " + primitives.nicefy_numbers(market["sell_offers"][resource][0]["price"])
                     market_analysis_surface.blit(sell,(0,0))
                 elif len(market["sell_offers"][resource]) == 0:
                     market_price = market["buy_offers"][resource][0]["price"]
-                    market_price_description = "Only buy offers. Highest is: " + "%.5g" % market["buy_offers"][resource][0]["price"]
+                    market_price_description = "Only buy offers. Highest is: " + primitives.nicefy_numbers(market["buy_offers"][resource][0]["price"])
                     market_analysis_surface.blit(buy,(0,self.graph_rect[3]-15))
 
                 else:
-                    market_price_description = "Highest buy offer: " + "%.5g" % market["buy_offers"][resource][0]["price"] + ". Lowest sell offer: " + "%.5g" % market["sell_offers"][resource][0]["price"]
+                    market_price_description = "Highest buy offer: " + primitives.nicefy_numbers(market["buy_offers"][resource][0]["price"]) + ". Lowest sell offer: " + primitives.nicefy_numbers(market["sell_offers"][resource][0]["price"])
                     market_price = (market["sell_offers"][resource][0]["price"] + market["buy_offers"][resource][0]["price"]) * 0.5
                     market_analysis_surface.blit(sell,(0,0))
                     market_analysis_surface.blit(buy,(0,self.graph_rect[3]-15))
@@ -2222,7 +2232,7 @@ class base_and_firm_market_window():
                     left_border = self.graph_rect[0]
                     width = x_length
                     #debugging_info = "exact y_pos: " + str(y_position_here + self.rect[1] + 21) + " top border: +" + str(top_border_length) + " bottom border: -" + str(bottom_border_length)
-                    self.positional_database["non_bidding_mode"][(left_border,top_border,width,height)] = {"linkto":provider[i],"text":provider[i].name + ": " + "%.5g" % prices[i],"figure":((left_border,y_position_here + self.graph_rect[1]),(left_border + width,y_position_here + self.graph_rect[1]))}
+                    self.positional_database["non_bidding_mode"][(left_border,top_border,width,height)] = {"linkto":provider[i],"text":provider[i].name + ": " + primitives.nicefy_numbers(prices[i]),"figure":((left_border,y_position_here + self.graph_rect[1]),(left_border + width,y_position_here + self.graph_rect[1]))}
 
 
                 #making x-axis scale
@@ -2243,7 +2253,7 @@ class base_and_firm_market_window():
                         break
                     x_pos_here = int((self.graph_rect[3]) * math.log10(x_mark_here) / math.log10(xlim[1]) )
                     pygame.draw.line(market_analysis_surface,(0,0,0),(x_pos_here,x_axis_vertical_position + mark_height/2),(x_pos_here,x_axis_vertical_position - mark_height/2))
-                    x_mark_label_text = "10^"+str(int(math.log10(x_mark_here)))
+                    x_mark_label_text = primitives.nicefy_numbers(x_mark_here)
                     if i == 0:
                         x_mark_label_text = x_mark_label_text + " units"
                     x_mark_label = global_variables.standard_font.render(x_mark_label_text,True,(0,0,0))
@@ -2320,7 +2330,7 @@ class base_and_firm_market_window():
                 left_border = x_position + self.graph_rect[0] - dot_size
                 top_border = y_position + self.graph_rect[1] - dot_size
                 if seller[i] is not None and buyer[i] is not None: #can happen with the empty startup transactions
-                    self.positional_database["non_bidding_mode"][(left_border,top_border,2*dot_size,2*dot_size)] = {"linkto":seller[i],"text":str(seller[i].name) + " to " + str(buyer[i].name) + ": 10^" + str(dot_size) + "units","figure":((dot_size),(x_position + self.graph_rect[0],y_position + self.graph_rect[1])),"debug":left_border- dot_size}
+                    self.positional_database["non_bidding_mode"][(left_border,top_border,2*dot_size,2*dot_size)] = {"linkto":seller[i],"text":str(seller[i].name) + " to " + str(buyer[i].name) + ": " + primitives.nicefy_numbers(quantity[i]) + " units","figure":((dot_size),(x_position + self.graph_rect[0],y_position + self.graph_rect[1])),"debug":left_border- dot_size}
 
             if len(price) != len(quantity) or len(price) != len(dates):
                 raise Exception("DEBUGGING WARNING: There is a problem with unequal length in the markethistoryplotter")
@@ -2404,7 +2414,30 @@ class base_and_firm_market_window():
 
 
         quantity_max = int(quantity_max)
-        quantity_range = (0,quantity_max)
+
+        def current_sell_stock_dict():
+            if isinstance(firm_selected, company.merchant):
+                if self.base_selected_for_merchant == firm_selected.from_location:
+                    return firm_selected.from_stock_dict
+                if self.base_selected_for_merchant == firm_selected.to_location:
+                    return firm_selected.to_stock_dict
+                raise Exception("The self.base_selected_for_merchant " + str(self.base_selected_for_merchant.name) + " was neither in the from or the to_location of " + str(firm_selected.name))
+            return firm_selected.stock_dict
+
+        def current_quantity_cap(selected_direction=None):
+            selected_direction = selected_direction or direction
+            sell_stock = current_sell_stock_dict() if selected_direction == "sell" else None
+            return quantity_cap_for_direction(selected_direction, resource, sell_stock, quantity_max)
+
+        def report_nothing_to_sell():
+            unit = self.solar_system_object_link.trade_resources[resource]["unit_of_measurment"]
+            print_dict = {"text":firm_selected.name + " has no " + unit + " of " + resource + " to sell.","type":"general gameplay info"}
+            self.solar_system_object_link.messages.append(print_dict)
+
+        if direction == "sell" and current_quantity_cap("sell") <= 0:
+            report_nothing_to_sell()
+
+        quantity_range = (0,current_quantity_cap(direction))
 
         if initial_quantity is not None:
             pre_selected_quantity = int(initial_quantity)
@@ -2445,7 +2478,7 @@ class base_and_firm_market_window():
         pre_selected_price_slider = market_price_to_slider(initial_price, highest_buy_offer, lowest_sell_offer, price_fallback_max)
 
 
-#        print "initial_quantity: " + str(initial_quantity)
+#        print "initial_quantity: " + primitives.nicefy_numbers(initial_quantity)
 #        print "quantity_range: " + str(quantity_range)
 #        print "initial_price: " + str(initial_price)
 #        print "price_range: " + str(price_range)
@@ -2460,7 +2493,7 @@ class base_and_firm_market_window():
         fixed_price_text = global_variables.standard_font.render("Set the price:",True,(0,0,0))
         self.action_surface.blit(fixed_price_text, (self.graph_rect[0], self.graph_rect[1] + height_to_draw))
         price_rect = pygame.Rect(self.graph_rect[0] + fixed_price_text.get_width(), self.graph_rect[1] + height_to_draw,self.graph_rect[2] - fixed_price_text.get_width(),fixed_price_text.get_height())
-        variable_price_text = global_variables.standard_font.render(str(int(initial_price)),True,(0,0,0))
+        variable_price_text = global_variables.standard_font.render(primitives.nicefy_numbers(initial_price),True,(0,0,0))
         self.action_surface.blit(variable_price_text, (price_rect[0], price_rect[1]))
 
         price_bar_left = self.graph_rect[0] + 10
@@ -2473,7 +2506,7 @@ class base_and_firm_market_window():
         def price_execute(label, price_rect):
             pygame.draw.rect(self.action_surface,(212,212,212),price_rect)
             price = market_price_from_slider(self.price_bar.position, highest_buy_offer, lowest_sell_offer, price_fallback_max)
-            variable_price_text = global_variables.standard_font.render(str(price),True,(0,0,0))
+            variable_price_text = global_variables.standard_font.render(primitives.nicefy_numbers(price),True,(0,0,0))
             self.action_surface.blit(variable_price_text, (price_rect[0], price_rect[1]))
             pygame.display.update(price_rect)
 
@@ -2494,7 +2527,7 @@ class base_and_firm_market_window():
         fixed_quantity_text = global_variables.standard_font.render("Set the quantity:",True,(0,0,0))
         self.action_surface.blit(fixed_quantity_text, (self.graph_rect[0], self.graph_rect[1] + height_to_draw))
         quantity_rect = pygame.Rect(self.graph_rect[0] + fixed_quantity_text.get_width(), self.graph_rect[1] + height_to_draw,self.graph_rect[2] - fixed_quantity_text.get_width(),fixed_quantity_text.get_height())
-        variable_quantity_text = global_variables.standard_font.render(str(initial_quantity),True,(0,0,0))
+        variable_quantity_text = global_variables.standard_font.render(primitives.nicefy_numbers(min(initial_quantity, current_quantity_cap(direction))),True,(0,0,0))
         self.action_surface.blit(variable_quantity_text, (quantity_rect[0], quantity_rect[1]))
 
         def current_quantity_anchor():
@@ -2506,14 +2539,18 @@ class base_and_firm_market_window():
 
         def quantity_execute(label, quantity_rect):
             pygame.draw.rect(self.action_surface,(212,212,212),quantity_rect)
-            quantity = quantity_from_slider(self.quantity_bar.position, current_quantity_anchor(), quantity_max)
-            variable_quantity_text = global_variables.standard_font.render(str(quantity),True,(0,0,0))
+            selected_direction = direction
+            if hasattr(self, "direction_buttons"):
+                selected_direction = self.direction_buttons.selected
+            quantity_cap = current_quantity_cap(selected_direction)
+            quantity = quantity_from_slider(self.quantity_bar.position, current_quantity_anchor(), quantity_max, max_quantity=quantity_cap)
+            variable_quantity_text = global_variables.standard_font.render(primitives.nicefy_numbers(quantity),True,(0,0,0))
             self.action_surface.blit(variable_quantity_text, (quantity_rect[0], quantity_rect[1]))
             pygame.display.update(quantity_rect)
 
         quantity_slider_range = (0, SLIDER_MAX)
         self.manual_bid_quantity_fallback_max = quantity_max
-        pre_selected_quantity_slider = quantity_to_slider(pre_selected_quantity, current_quantity_anchor(), quantity_max)
+        pre_selected_quantity_slider = quantity_to_slider(pre_selected_quantity, current_quantity_anchor(), quantity_max, max_quantity=current_quantity_cap(direction))
         self.quantity_bar = gui_components.hscrollbar(self.action_surface,
                                   quantity_execute,
                                   (self.graph_rect[0] + 10, self.graph_rect[1] + height_to_draw + 20),
@@ -2536,6 +2573,8 @@ class base_and_firm_market_window():
 #            print label
 #            print function_parameter
             if hasattr(self, "quantity_bar"):
+                if self.direction_buttons.selected == "sell" and current_quantity_cap("sell") <= 0:
+                    report_nothing_to_sell()
                 quantity_execute(self.quantity_bar.position, quantity_rect)
 
 
@@ -2602,14 +2641,26 @@ class base_and_firm_market_window():
         quantity_fallback_max = max(1, getattr(self, "manual_bid_quantity_fallback_max", self.quantity_bar.range_of_values[1]))
         quantity_anchor = quantity_anchor_for_direction(firm_selected.input_output_dict, direction, resource)
         price = market_price_from_slider(self.price_bar.position, highest_buy_offer, lowest_sell_offer, fallback_max)
-        quantity = quantity_from_slider(self.quantity_bar.position, quantity_anchor, quantity_fallback_max)
+        quantity_stock_dict = None
+        if direction == "sell":
+            if isinstance(firm_selected, company.merchant):
+                if market == firm_selected.from_location.market:
+                    quantity_stock_dict = firm_selected.from_stock_dict
+                elif market == firm_selected.to_location.market:
+                    quantity_stock_dict = firm_selected.to_stock_dict
+                else:
+                    raise Exception("Unknown direction for merchant type firm")
+            else:
+                quantity_stock_dict = firm_selected.stock_dict
+        quantity_cap = quantity_cap_for_direction(direction, resource, quantity_stock_dict, quantity_fallback_max)
+        quantity = quantity_from_slider(self.quantity_bar.position, quantity_anchor, quantity_fallback_max, max_quantity=quantity_cap if direction == "sell" else None)
 
         #determining unit
         unit = self.solar_system_object_link.trade_resources[resource]["unit_of_measurment"]
 
         if direction == "buy":
             if price * quantity > firm_selected.owner.capital:
-                print_dict = {"text":"Too low capital to bid for " + str(quantity) + " " + str(unit) + " of " + str(resource) + " at price " + str(price),"type":"general gameplay info"}
+                print_dict = {"text":"Too low capital to bid for " + primitives.nicefy_numbers(quantity) + " " + str(unit) + " of " + str(resource) + " at price " + primitives.nicefy_numbers(price),"type":"general gameplay info"}
                 self.solar_system_object_link.messages.append(print_dict)
                 return
             own_offer = {"resource":resource,"price":float(price),"buyer":firm_selected,"name":firm_selected.name,"quantity":int(quantity),"date":self.solar_system_object_link.current_date}
@@ -2623,8 +2674,12 @@ class base_and_firm_market_window():
                     raise Exception("Unknown direction for merchant type firm")
             else:
                 quantity_available = firm_selected.stock_dict[resource]
+            if quantity_available <= 0:
+                print_dict = {"text":firm_selected.name + " has no " + str(unit) + " of " + str(resource) + " to sell.","type":"general gameplay info"}
+                self.solar_system_object_link.messages.append(print_dict)
+                return
             if quantity > quantity_available:
-                print_dict = {"text":firm_selected.name + " only has " + str(firm_selected.stock_dict[resource]) + " " + str(unit) + " and can't offer " + str(quantity) + " for sale","type":"general gameplay info"}
+                print_dict = {"text":firm_selected.name + " only has " + primitives.nicefy_numbers(quantity_available) + " " + str(unit) + " and can't offer " + primitives.nicefy_numbers(quantity) + " for sale","type":"general gameplay info"}
                 self.solar_system_object_link.messages.append(print_dict)
                 return
             own_offer = {"resource":resource,"price":float(price),"seller":firm_selected,"name":firm_selected.name,"quantity":int(quantity),"date":self.solar_system_object_link.current_date}
@@ -2633,7 +2688,7 @@ class base_and_firm_market_window():
 
         firm_selected.make_market_bid(market,own_offer)
 
-        print_dict = {"text":firm_selected.name + " succesfully made a " + str(direction) + " bid for " + str(quantity) + " " + str(unit) + " of " + str(resource) + " at price " + str(price),"type":"general gameplay info"}
+        print_dict = {"text":firm_selected.name + " succesfully made a " + str(direction) + " bid for " + primitives.nicefy_numbers(quantity) + " " + str(unit) + " of " + str(resource) + " at price " + primitives.nicefy_numbers(price),"type":"general gameplay info"}
         self.solar_system_object_link.messages.append(print_dict)
         self.graph_selected = "market bids"
         return "clear"
@@ -2695,7 +2750,7 @@ class base_and_firm_market_window():
                                 if price < 0:
                                     price = 0
                                     if self.solar_system_object_link.message_printing["debugging"]:
-                                        print_dict = {"text":"Changed price from " + str(price) + " to 0","type":"debugging"}
+                                        print_dict = {"text":"Changed price from " + primitives.nicefy_numbers(price) + " to 0","type":"debugging"}
                                         self.solar_system_object_link.messages.append(print_dict)
 
                             else:
@@ -2714,7 +2769,7 @@ class base_and_firm_market_window():
                             else:
                                 quantity = None
 
-#                            print "click at " + str((x_relative_position,y_relative_position)) + " gives price: " + str(price) + " and qt: " + str(quantity)
+#                            print "click at " + str((x_relative_position,y_relative_position)) + " gives price: " + primitives.nicefy_numbers(price) + " and qt: " + primitives.nicefy_numbers(quantity)
                             self.make_manual_bid(price,quantity)
 
 
@@ -3153,14 +3208,15 @@ class base_build_menu():
         self.action_surface.blit(text, (self.rect[0] + 90, self.rect[1] + 150))
 
 
+        firm_size_label_x = self.rect[0] + 45
         small_label = global_variables.standard_font.render("Small",True,(0,0,0))
-        self.action_surface.blit(small_label, (self.rect[0] + 40, self.rect[1] + 40))
+        self.action_surface.blit(small_label, (firm_size_label_x, self.rect[1] + 40))
 
-        medium_label = global_variables.standard_font.render("Medium",True,(0,0,0))
-        self.action_surface.blit(medium_label, (self.rect[0] + 40, self.rect[1] + int(self.rect[3] / 2)))
+        medium_label = global_variables.standard_font.render("Mid",True,(0,0,0))
+        self.action_surface.blit(medium_label, (firm_size_label_x, self.rect[1] + int(self.rect[3] / 2)))
 
         large_label = global_variables.standard_font.render("Large",True,(0,0,0))
-        self.action_surface.blit(large_label, (self.rect[0] + 40, self.rect[1] + self.rect[3]-  50))
+        self.action_surface.blit(large_label, (firm_size_label_x, self.rect[1] + self.rect[3]-  50))
 
 
         def execute(label, technology):
@@ -3173,7 +3229,7 @@ class base_build_menu():
 
             selected_size = firm_size_from_slider(self.slider.position, max_size)
             self.selected_firm_size = selected_size
-            size_info = global_variables.standard_font_small.render("size: " + str(selected_size),True,(0,0,0))
+            size_info = global_variables.standard_font_small.render("size: " + primitives.nicefy_numbers(selected_size),True,(0,0,0))
             self.action_surface.blit(size_info, (self.rect[0] + 130, self.rect[1] + 170))
             lineno = 0
             for put in ["input","output"]:

--- a/gui_components.py
+++ b/gui_components.py
@@ -882,28 +882,8 @@ class fast_list():
                         else:
                             data_point_here = data[rowname][column_entry]
 
-                        if isinstance(data_point_here,int) or isinstance(data_point_here,int) or isinstance(data_point_here,float):
-                            if isinstance(data_point_here,float):
-                                if abs(data_point_here) > 1000:
-                                    data_point_here = int(data_point_here)
-                                else:
-                                    data_point_here = "%.4g" % data_point_here
-
-                            if isinstance(data_point_here,int) or isinstance(data_point_here,int):
-                                if abs(data_point_here) > 1000*1000*1000*1000*1000*3:
-                                    data_point_here = "%.4g" % data_point_here
-                                elif abs(data_point_here) > 1000*1000*1000*1000*3:
-                                    data_point_here = str(int(data_point_here / (1000*1000*1000*1000) )) + " trillion"
-                                elif abs(data_point_here) > 1000*1000*1000*3:
-                                    data_point_here = str(int(data_point_here / (1000*1000*1000) )) + " billion"
-                                elif abs(data_point_here) > 1000*1000*3:
-                                    data_point_here = str(int(data_point_here / (1000*1000) )) + " million"
-                                elif abs(data_point_here) > 1000*3:
-                                    data_point_here = str(int(data_point_here / 1000)) + " thousand"
-                                else:
-                                    data_point_here = str(data_point_here)
-
-                            #data_point_here = "%.3g" % data_point_here
+                        if isinstance(data_point_here, (int, float)):
+                            data_point_here = primitives.nicefy_numbers(data_point_here)
                         else:
                             data_point_here = str(data_point_here)
 

--- a/primitives.py
+++ b/primitives.py
@@ -45,8 +45,9 @@ def make_linear_x_axis(surface,frame_size,xlim,solar_system_object_link,unit="")
             tick_mark_rendered_value_size = global_variables.standard_font.size(str(tick_mark_value))
         else:
             tick_mark_value = xlim[1] - ((xlim[1]-xlim[0]) * (i/float(tick_marks-1)))
-            tick_mark_rendered_value = global_variables.standard_font.render("%.3g" %tick_mark_value,True,(0,0,0))
-            tick_mark_rendered_value_size = global_variables.standard_font.size("%.3g" %tick_mark_value)
+            tick_mark_label = nicefy_numbers(tick_mark_value)
+            tick_mark_rendered_value = global_variables.standard_font.render(tick_mark_label,True,(0,0,0))
+            tick_mark_rendered_value_size = global_variables.standard_font.size(tick_mark_label)
 
         pygame.draw.line(surface,(0,0,0),(tick_mark_placement,size[1]-frame_size-tick_mark_width),(tick_mark_placement,size[1]-frame_size+tick_mark_width))
         x_correction = 0
@@ -90,8 +91,9 @@ def make_linear_y_axis(surface,frame_size,ylim,solar_system_object_link, unit=""
             tick_mark_rendered_value_size = global_variables.standard_font.size(str(tick_mark_value))
         else:
             tick_mark_value = ylim[1] - ((ylim[1]-ylim[0]) * (i/float(tick_marks-1)))
-            tick_mark_rendered_value = global_variables.standard_font.render("%.3g" %tick_mark_value,True,(0,0,0))
-            tick_mark_rendered_value_size = global_variables.standard_font.size("%.3g" %tick_mark_value)
+            tick_mark_label = nicefy_numbers(tick_mark_value)
+            tick_mark_rendered_value = global_variables.standard_font.render(tick_mark_label,True,(0,0,0))
+            tick_mark_rendered_value_size = global_variables.standard_font.size(tick_mark_label)
 
         pygame.draw.line(surface,(0,0,0),(frame_size-tick_mark_width,tick_mark_placement),(frame_size+tick_mark_width,tick_mark_placement))
 
@@ -410,31 +412,42 @@ def listify_tabular_data(data,size,manager,sort_by="rownames",column_order=None,
 
 
 
+def _trim_compact_number(value):
+    if value >= 100 or abs(value - round(value)) < 0.05:
+        text = str(int(round(value)))
+    elif value >= 10:
+        text = f"{value:.1f}"
+    else:
+        text = f"{value:.2f}"
+    return text.rstrip("0").rstrip(".")
+
+
 def nicefy_numbers(number):
+    """Return a compact human-readable number without scientific notation.
+
+    Uses game-style suffixes: K, M, B, T, then Qa/Qi/Sx/Sp/Oc/No/Dc.
     """
-    Takes a number and returns a string that has had added billion or trillion or whatever
-    """
-    if not (isinstance(number,int) or isinstance(number,int) or isinstance(number,float)):
+    if not isinstance(number, (int, float)):
         raise Exception("The received number was not of required class int, long or float")
 
-    if isinstance(number,float):
-        if abs(number) > 1000:
-            number = int(number)
-        else:
-            number = "%.4g" % number
+    if number == 0:
+        return "0"
 
-    if isinstance(number,int) or isinstance(number,int):
-        if abs(number) > 1000*1000*1000*1000*1000*3:
-            number = "%.4g" % number
-        elif abs(number) > 1000*1000*1000*1000*3:
-            number = str(int(number / (1000*1000*1000*1000) )) + " trillion"
-        elif abs(number) > 1000*1000*1000*3:
-            number = str(int(number / (1000*1000*1000) )) + " billion"
-        elif abs(number) > 1000*1000*3:
-            number = str(int(number / (1000*1000) )) + " million"
-        elif abs(number) > 1000*3:
-            number = str(int(number / 1000)) + " thousand"
-        else:
-            number = str(number)
+    sign = "-" if number < 0 else ""
+    value = abs(float(number))
+    suffixes = ["", "K", "M", "B", "T", "Qa", "Qi", "Sx", "Sp", "Oc", "No", "Dc"]
+    suffix_index = 0
+    while value >= 1000 and suffix_index < len(suffixes) - 1:
+        value /= 1000.0
+        suffix_index += 1
 
-    return number
+    if suffix_index == 0:
+        if isinstance(number, int) or value >= 100:
+            text = str(int(round(value)))
+        elif value >= 1:
+            text = f"{value:.2f}".rstrip("0").rstrip(".")
+        else:
+            text = f"{value:.6f}".rstrip("0").rstrip(".")
+    else:
+        text = _trim_compact_number(value) + suffixes[suffix_index]
+    return sign + text

--- a/tests/test_bidding_slider_scaling.py
+++ b/tests/test_bidding_slider_scaling.py
@@ -10,6 +10,7 @@ from bidding_slider_scaling import (
     market_price_from_slider,
     market_price_to_slider,
     quantity_anchor_for_direction,
+    quantity_cap_for_direction,
     quantity_from_slider,
     quantity_to_slider,
 )
@@ -106,3 +107,17 @@ def test_quantity_anchor_for_direction_uses_inputs_for_buy_and_outputs_for_sell(
     assert quantity_anchor_for_direction(process, "sell", "education") == 123
     assert quantity_anchor_for_direction(process, "buy", "education") is None
     assert quantity_anchor_for_direction(process, "sell", "labor") is None
+
+
+def test_sell_quantity_mapping_can_be_capped_by_available_stock():
+    assert quantity_from_slider(SLIDER_MAX, 123, fallback_max=10, max_quantity=10) == 10
+    assert quantity_from_slider(SLIDER_HIGH_ANCHOR, 123, fallback_max=0, max_quantity=0) == 0
+    assert quantity_to_slider(999, 123, fallback_max=10, max_quantity=10) == SLIDER_MAX
+
+
+def test_quantity_cap_for_direction_uses_stock_for_sell_and_fallback_for_buy():
+    stock = {"labor": 0, "education": 12}
+
+    assert quantity_cap_for_direction("sell", "education", stock, buy_fallback_max=500) == 12
+    assert quantity_cap_for_direction("sell", "labor", stock, buy_fallback_max=500) == 0
+    assert quantity_cap_for_direction("buy", "labor", stock, buy_fallback_max=500) == 500

--- a/tests/test_company_byproducts.py
+++ b/tests/test_company_byproducts.py
@@ -33,7 +33,7 @@ class _FakePlanet:
         self.gas_changes.append((gas, ton))
 
 
-def _production_firm(byproducts, planet):
+def _production_firm(byproducts, planet, outputs=None):
     sol = _FakeSolarSystem()
     firm = company.firm.__new__(company.firm)
     firm.name = "test producer"
@@ -44,10 +44,12 @@ def _production_firm(byproducts, planet):
     firm.stock_dict = {}
     firm.input_output_dict = {
         "input": {},
-        "output": {},
+        "output": outputs or {},
         "timeframe": 30,
         "byproducts": byproducts,
     }
+    for resource in firm.input_output_dict["output"]:
+        firm.stock_dict[resource] = 0
     return firm, sol
 
 
@@ -66,3 +68,12 @@ def test_atmospheric_byproduct_still_changes_planet_atmosphere():
     firm.execute_stock_change(sol.start_date + datetime.timedelta(days=60))
 
     assert planet.gas_changes == [("carbondioxide", 20)]
+
+
+def test_non_trade_effect_output_does_not_need_trade_resource_or_stockpile():
+    firm, sol = _production_firm({}, _FakePlanet(), outputs={"terraforming": 10})
+
+    firm.execute_stock_change(sol.start_date + datetime.timedelta(days=60))
+
+    assert firm.last_consumption_date == sol.start_date + datetime.timedelta(days=60)
+    assert "terraforming" not in firm.stock_dict

--- a/tests/test_economy_data.py
+++ b/tests/test_economy_data.py
@@ -10,7 +10,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # Technology input/output entries should normally name stockpiled/traded
 # resources. Keep explicit non-stockpiled gameplay effects here if technology
 # data ever needs an effect output that should not be listed in trade resources.
-NON_STOCKPILED_TECHNOLOGY_EFFECTS = set()
+NON_STOCKPILED_TECHNOLOGY_EFFECTS = {"terraforming"}
+
+
+def test_terraforming_is_not_a_trade_resource_product():
+    assert "terraforming" not in _trade_resources()
 
 
 def _trade_resources():

--- a/tests/test_gui_catastrophes.py
+++ b/tests/test_gui_catastrophes.py
@@ -1,0 +1,49 @@
+import types
+
+import pygame
+
+import gui
+from display import Display
+
+
+class _FakeEarth:
+    def __init__(self, bases):
+        self.bases = bases
+        self.explosions = []
+
+    def explode(self, size, strength, bases_chosen, action_surface):
+        self.explosions.append((size, strength, bases_chosen, action_surface))
+
+
+def _window_with_earth(earth):
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    window = gui.file_window.__new__(gui.file_window)
+    window.action_surface = pygame.Surface((100, 100))
+    window.solar_system_object_link = types.SimpleNamespace(
+        display_mode=Display.PLANETARY,
+        planets={"earth": earth},
+        messages=[],
+    )
+    return window
+
+
+def test_nuclear_war_skips_missing_configured_targets_without_crashing():
+    earth = _FakeEarth({"stockholm": object()})
+    window = _window_with_earth(earth)
+
+    window.nuclear_war(None, None)
+
+    assert len(earth.explosions) == 1
+    assert list(earth.explosions[0][2]) == ["stockholm"]
+    assert any("glasgow" in message["text"] for message in window.solar_system_object_link.messages)
+
+
+def test_nuclear_war_reports_if_no_configured_targets_exist():
+    earth = _FakeEarth({})
+    window = _window_with_earth(earth)
+
+    window.nuclear_war(None, None)
+
+    assert earth.explosions == []
+    assert any("not available" in message["text"] for message in window.solar_system_object_link.messages)

--- a/tests/test_number_formatting.py
+++ b/tests/test_number_formatting.py
@@ -1,0 +1,25 @@
+import primitives
+
+
+def test_nicefy_numbers_uses_compact_suffixes_without_scientific_notation():
+    cases = {
+        999: "999",
+        1_000: "1K",
+        1_500: "1.5K",
+        1_000_000: "1M",
+        1_200_000_000: "1.2B",
+        2_000_000_000_000: "2T",
+        1_500_000_000_000_000: "1.5Qa",
+    }
+
+    for value, expected in cases.items():
+        formatted = primitives.nicefy_numbers(value)
+        assert formatted == expected
+        assert "e" not in formatted.lower()
+
+
+def test_nicefy_numbers_handles_negative_and_decimal_values_compactly():
+    assert primitives.nicefy_numbers(-1_500) == "-1.5K"
+    assert primitives.nicefy_numbers(12.3456) == "12.35"
+    assert primitives.nicefy_numbers(0.000123) == "0.000123"
+    assert "e" not in primitives.nicefy_numbers(10**30).lower()


### PR DESCRIPTION
## Summary
- Cap sell-order quantities at current stock and show a message when there is nothing to sell
- Switch market/tooltip/bid number displays to compact K/M/B/T+ formatting instead of scientific notation or long words
- Rename the firm-size label from Medium to Mid and shift labels slightly right
- Remove terraforming as a trade product while tolerating non-stockpiled technology effects
- Make Nuclear war skip/report missing configured bases instead of crashing

## Test plan
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/ubuntu/leo_data/highfrontier/.venv/bin/python -m pytest tests/test_bidding_slider_scaling.py tests/test_number_formatting.py tests/test_company_byproducts.py tests/test_economy_data.py tests/test_gui_catastrophes.py tests/test_gui_components.py -q
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 /home/ubuntu/leo_data/highfrontier/.venv/bin/python -m pytest -q
- /home/ubuntu/leo_data/highfrontier/.venv/bin/python -m compileall -q .